### PR TITLE
fix: resolve embedded mode data persistence across MCP tool calls

### DIFF
--- a/src/lib/store-factory.ts
+++ b/src/lib/store-factory.ts
@@ -7,6 +7,10 @@ import { HttpAdapter } from './http-adapter.js';
 import { EmbeddedAdapter } from './embedded-adapter.js';
 import { materializeInferences } from './reasoner.js';
 
+// Singleton cache for embedded mode — keeps data alive across MCP tool calls.
+let cachedAdapter: EmbeddedAdapter | null = null;
+let loadedFileKeys = new Set<string>();
+
 export function createAdapter(config: OpenTologyConfig): StoreAdapter {
   if (config.mode === 'embedded') {
     return new EmbeddedAdapter();
@@ -14,27 +18,50 @@ export function createAdapter(config: OpenTologyConfig): StoreAdapter {
   return new HttpAdapter(config.endpoint ?? 'http://localhost:7878');
 }
 
-export async function createReadyAdapter(config: OpenTologyConfig): Promise<StoreAdapter> {
-  const adapter = createAdapter(config);
+/**
+ * Reset the cached embedded adapter. Useful for tests or after config-level
+ * changes that invalidate the entire store (e.g. project re-init).
+ */
+export function resetAdapterCache(): void {
+  cachedAdapter = null;
+  loadedFileKeys = new Set();
+}
 
-  if (config.mode === 'embedded' && adapter instanceof EmbeddedAdapter) {
-    // Load all tracked files for all graphs
-    const allGraphs = [config.graphUri, ...Object.keys(config.graphs ?? {}).map(k => config.graphs![k])];
-    for (const graphUri of allGraphs) {
-      const files = getTrackedFiles(config, graphUri);
-      for (const f of files) {
+export async function createReadyAdapter(config: OpenTologyConfig): Promise<StoreAdapter> {
+  if (config.mode !== 'embedded') {
+    return new HttpAdapter(config.endpoint ?? 'http://localhost:7878');
+  }
+
+  // Reuse cached adapter so data persists across MCP tool calls.
+  if (!cachedAdapter) {
+    cachedAdapter = new EmbeddedAdapter();
+    loadedFileKeys = new Set();
+  }
+
+  const adapter = cachedAdapter;
+
+  // Incrementally load only newly-tracked files into the existing store.
+  const allGraphs = [config.graphUri, ...Object.keys(config.graphs ?? {}).map(k => config.graphs![k])];
+  let newFilesLoaded = false;
+  for (const graphUri of allGraphs) {
+    const files = getTrackedFiles(config, graphUri);
+    for (const f of files) {
+      const key = `${graphUri}::${resolve(f)}`;
+      if (!loadedFileKeys.has(key)) {
         try {
           const content = readFileSync(resolve(f), 'utf-8');
           adapter.loadTurtleIntoGraph(content, graphUri);
+          loadedFileKeys.add(key);
+          newFilesLoaded = true;
         } catch {
           // File may have been deleted — skip silently
         }
       }
     }
+  }
 
-    // Auto-run inference for embedded mode on every adapter creation.
-    // The embedded store is ephemeral, so inferred triples must be re-materialized
-    // each time a new adapter is constructed (e.g. on each CLI invocation).
+  // Re-materialize inferences only when new file data was loaded.
+  if (newFilesLoaded) {
     const allGraphUris = new Set<string>();
     allGraphUris.add(config.graphUri);
     if (config.graphs) {

--- a/tests/integration/embedded-adapter.test.ts
+++ b/tests/integration/embedded-adapter.test.ts
@@ -1,0 +1,361 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { EmbeddedAdapter } from '../../src/lib/embedded-adapter.js';
+
+const GRAPH = 'https://test.org/graph';
+
+describe('EmbeddedAdapter', () => {
+  let adapter: EmbeddedAdapter;
+
+  beforeEach(() => {
+    adapter = new EmbeddedAdapter();
+  });
+
+  // ── 1. sparqlUpdate + sparqlQuery ─────────────────────────────────────
+
+  describe('sparqlUpdate + sparqlQuery', () => {
+    it('inserts data via SPARQL UPDATE and queries it back', async () => {
+      await adapter.sparqlUpdate(`
+        INSERT DATA {
+          GRAPH <${GRAPH}> {
+            <http://example.org/Alice> <http://example.org/name> "Alice" .
+          }
+        }
+      `);
+
+      const result = await adapter.sparqlQuery(`
+        SELECT ?name WHERE {
+          GRAPH <${GRAPH}> {
+            <http://example.org/Alice> <http://example.org/name> ?name .
+          }
+        }
+      `);
+
+      expect(result.results.bindings).toHaveLength(1);
+      expect(result.results.bindings[0]!['name']!.value).toBe('Alice');
+      expect(result.results.bindings[0]!['name']!.type).toBe('literal');
+    });
+  });
+
+  // ── 2. insertTurtle + sparqlQuery round-trip ──────────────────────────
+
+  describe('insertTurtle + sparqlQuery round-trip', () => {
+    it('inserts Turtle and queries it back', async () => {
+      const turtle = `
+        @prefix ex: <http://example.org/> .
+        ex:Bob ex:age "30" .
+      `;
+
+      await adapter.insertTurtle(GRAPH, turtle);
+
+      const result = await adapter.sparqlQuery(`
+        SELECT ?age WHERE {
+          GRAPH <${GRAPH}> {
+            <http://example.org/Bob> <http://example.org/age> ?age .
+          }
+        }
+      `);
+
+      expect(result.results.bindings).toHaveLength(1);
+      expect(result.results.bindings[0]!['age']!.value).toBe('30');
+    });
+  });
+
+  // ── 3. getGraphTripleCount ────────────────────────────────────────────
+
+  describe('getGraphTripleCount', () => {
+    it('returns 0 for an empty graph', async () => {
+      const count = await adapter.getGraphTripleCount(GRAPH);
+      expect(count).toBe(0);
+    });
+
+    it('returns correct count after inserts', async () => {
+      const turtle = `
+        @prefix ex: <http://example.org/> .
+        ex:A ex:p "1" .
+        ex:B ex:p "2" .
+        ex:C ex:p "3" .
+      `;
+      await adapter.insertTurtle(GRAPH, turtle);
+
+      const count = await adapter.getGraphTripleCount(GRAPH);
+      expect(count).toBe(3);
+    });
+  });
+
+  // ── 4. exportGraph ────────────────────────────────────────────────────
+
+  describe('exportGraph', () => {
+    it('returns valid Turtle that can be re-parsed', async () => {
+      const turtle = `
+        @prefix ex: <http://example.org/> .
+        ex:X ex:rel ex:Y .
+      `;
+      await adapter.insertTurtle(GRAPH, turtle);
+
+      const exported = await adapter.exportGraph(GRAPH);
+      expect(exported).toBeTruthy();
+      expect(exported).toContain('http://example.org/X');
+      expect(exported).toContain('http://example.org/Y');
+
+      // The exported Turtle can be loaded back into a fresh adapter
+      const adapter2 = new EmbeddedAdapter();
+      await adapter2.insertTurtle(GRAPH, exported);
+      const count = await adapter2.getGraphTripleCount(GRAPH);
+      expect(count).toBe(1);
+    });
+  });
+
+  // ── 5. constructQuery ─────────────────────────────────────────────────
+
+  describe('constructQuery', () => {
+    it('returns Turtle with the correct triples', async () => {
+      const turtle = `
+        @prefix ex: <http://example.org/> .
+        ex:A ex:knows ex:B .
+        ex:A ex:knows ex:C .
+        ex:D ex:likes ex:E .
+      `;
+      await adapter.insertTurtle(GRAPH, turtle);
+
+      const result = await adapter.constructQuery(`
+        CONSTRUCT { ?s <http://example.org/knows> ?o }
+        WHERE {
+          GRAPH <${GRAPH}> { ?s <http://example.org/knows> ?o }
+        }
+      `);
+
+      expect(result).toContain('http://example.org/A');
+      expect(result).toContain('http://example.org/B');
+      expect(result).toContain('http://example.org/C');
+      // Should not contain the "likes" triple
+      expect(result).not.toContain('http://example.org/likes');
+    });
+  });
+
+  // ── 6. dropGraph ──────────────────────────────────────────────────────
+
+  describe('dropGraph', () => {
+    it('removes all triples, count goes to 0', async () => {
+      const turtle = `
+        @prefix ex: <http://example.org/> .
+        ex:A ex:p ex:B .
+        ex:C ex:p ex:D .
+      `;
+      await adapter.insertTurtle(GRAPH, turtle);
+      expect(await adapter.getGraphTripleCount(GRAPH)).toBe(2);
+
+      await adapter.dropGraph(GRAPH);
+      expect(await adapter.getGraphTripleCount(GRAPH)).toBe(0);
+    });
+  });
+
+  // ── 7. deleteTriples (turtle mode) ────────────────────────────────────
+
+  describe('deleteTriples (turtle mode)', () => {
+    it('deletes specific triples via turtle, leaving others', async () => {
+      const turtle = `
+        @prefix ex: <http://example.org/> .
+        ex:A ex:p ex:B .
+        ex:A ex:p ex:C .
+        ex:A ex:p ex:D .
+      `;
+      await adapter.insertTurtle(GRAPH, turtle);
+      expect(await adapter.getGraphTripleCount(GRAPH)).toBe(3);
+
+      await adapter.deleteTriples(GRAPH, {
+        turtle: `
+          @prefix ex: <http://example.org/> .
+          ex:A ex:p ex:B .
+        `,
+      });
+
+      expect(await adapter.getGraphTripleCount(GRAPH)).toBe(2);
+
+      // Verify the deleted triple is gone
+      const result = await adapter.sparqlQuery(`
+        SELECT ?o WHERE {
+          GRAPH <${GRAPH}> { <http://example.org/A> <http://example.org/p> ?o }
+        } ORDER BY ?o
+      `);
+      const values = result.results.bindings.map((b) => b['o']!.value);
+      expect(values).toContain('http://example.org/C');
+      expect(values).toContain('http://example.org/D');
+      expect(values).not.toContain('http://example.org/B');
+    });
+  });
+
+  // ── 8. deleteTriples (where mode) ─────────────────────────────────────
+
+  describe('deleteTriples (where mode)', () => {
+    it('deletes triples matching a WHERE pattern', async () => {
+      const turtle = `
+        @prefix ex: <http://example.org/> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        ex:A rdf:type ex:Foo .
+        ex:A ex:val "hello" .
+        ex:B rdf:type ex:Bar .
+        ex:B ex:val "world" .
+      `;
+      await adapter.insertTurtle(GRAPH, turtle);
+      expect(await adapter.getGraphTripleCount(GRAPH)).toBe(4);
+
+      // Delete all triples about ex:A
+      await adapter.deleteTriples(GRAPH, {
+        where: 'FILTER(?s = <http://example.org/A>)',
+      });
+
+      expect(await adapter.getGraphTripleCount(GRAPH)).toBe(2);
+
+      // Verify only ex:B triples remain
+      const result = await adapter.sparqlQuery(`
+        SELECT ?s WHERE {
+          GRAPH <${GRAPH}> { ?s ?p ?o }
+        }
+      `);
+      const subjects = result.results.bindings.map((b) => b['s']!.value);
+      expect(subjects.every((s) => s === 'http://example.org/B')).toBe(true);
+    });
+  });
+
+  // ── 9. deleteTriples (no args) ────────────────────────────────────────
+
+  describe('deleteTriples (no args)', () => {
+    it('throws an error when neither turtle nor where is provided', async () => {
+      await expect(
+        adapter.deleteTriples(GRAPH, {}),
+      ).rejects.toThrow('either options.turtle or options.where must be provided');
+    });
+  });
+
+  // ── 10. diffGraph ─────────────────────────────────────────────────────
+
+  describe('diffGraph', () => {
+    it('detects added, removed, and unchanged triples', async () => {
+      const original = `
+        @prefix ex: <http://example.org/> .
+        ex:A ex:p ex:B .
+        ex:A ex:p ex:C .
+      `;
+      await adapter.insertTurtle(GRAPH, original);
+
+      // Modified version: keeps ex:A ex:p ex:B, drops ex:A ex:p ex:C, adds ex:A ex:p ex:D
+      const modified = `
+        @prefix ex: <http://example.org/> .
+        ex:A ex:p ex:B .
+        ex:A ex:p ex:D .
+      `;
+
+      const diff = await adapter.diffGraph(GRAPH, modified);
+
+      // "added" = in local but not in remote
+      expect(diff.added).toHaveLength(1);
+      expect(diff.added[0]).toContain('http://example.org/D');
+
+      // "removed" = in remote but not in local
+      expect(diff.removed).toHaveLength(1);
+      expect(diff.removed[0]).toContain('http://example.org/C');
+
+      // "unchanged" = present in both
+      expect(diff.unchanged).toBe(1);
+    });
+  });
+
+  // ── 11. getSchemaOverview ─────────────────────────────────────────────
+
+  describe('getSchemaOverview', () => {
+    it('returns classes, properties, prefixes, and tripleCount', async () => {
+      const turtle = `
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix ex: <http://example.org/> .
+        ex:Alice rdf:type ex:Person .
+        ex:Alice ex:name "Alice" .
+        ex:Bob rdf:type ex:Person .
+        ex:Bob ex:age "30" .
+      `;
+      await adapter.insertTurtle(GRAPH, turtle);
+
+      const overview = await adapter.getSchemaOverview(GRAPH);
+
+      expect(overview.tripleCount).toBe(4);
+      expect(overview.classes).toContain('http://example.org/Person');
+      expect(overview.properties).toContain('http://example.org/name');
+      expect(overview.properties).toContain('http://example.org/age');
+      expect(overview.properties).toContain('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+      expect(Object.keys(overview.prefixes).length).toBeGreaterThan(0);
+    });
+  });
+
+  // ── 12. getClassDetails ───────────────────────────────────────────────
+
+  describe('getClassDetails', () => {
+    it('returns instance count, properties, and sample triples', async () => {
+      const turtle = `
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix ex: <http://example.org/> .
+        ex:Alice rdf:type ex:Person .
+        ex:Alice ex:name "Alice" .
+        ex:Bob rdf:type ex:Person .
+        ex:Bob ex:name "Bob" .
+        ex:Bob ex:age "25" .
+      `;
+      await adapter.insertTurtle(GRAPH, turtle);
+
+      const details = await adapter.getClassDetails(GRAPH, 'http://example.org/Person');
+
+      expect(details.classUri).toBe('http://example.org/Person');
+      expect(details.instanceCount).toBe(2);
+      expect(details.properties.length).toBeGreaterThan(0);
+
+      const propNames = details.properties.map((p) => p.property);
+      expect(propNames).toContain('http://example.org/name');
+
+      expect(details.sampleTriples.length).toBeGreaterThan(0);
+      expect(details.sampleTriples.length).toBeLessThanOrEqual(5);
+    });
+  });
+
+  // ── 13. Named graph isolation ─────────────────────────────────────────
+
+  describe('named graph isolation', () => {
+    const GRAPH_A = 'https://test.org/graphA';
+    const GRAPH_B = 'https://test.org/graphB';
+
+    it('data in graph A is not visible in graph B', async () => {
+      const turtle = `
+        @prefix ex: <http://example.org/> .
+        ex:X ex:p ex:Y .
+      `;
+      await adapter.insertTurtle(GRAPH_A, turtle);
+
+      const countA = await adapter.getGraphTripleCount(GRAPH_A);
+      const countB = await adapter.getGraphTripleCount(GRAPH_B);
+
+      expect(countA).toBe(1);
+      expect(countB).toBe(0);
+
+      // Query on graph B returns empty
+      const result = await adapter.sparqlQuery(`
+        SELECT ?s WHERE { GRAPH <${GRAPH_B}> { ?s ?p ?o } }
+      `);
+      expect(result.results.bindings).toHaveLength(0);
+    });
+
+    it('dropping graph A does not affect graph B', async () => {
+      const turtleA = `
+        @prefix ex: <http://example.org/> .
+        ex:A1 ex:p ex:A2 .
+      `;
+      const turtleB = `
+        @prefix ex: <http://example.org/> .
+        ex:B1 ex:p ex:B2 .
+      `;
+      await adapter.insertTurtle(GRAPH_A, turtleA);
+      await adapter.insertTurtle(GRAPH_B, turtleB);
+
+      await adapter.dropGraph(GRAPH_A);
+
+      expect(await adapter.getGraphTripleCount(GRAPH_A)).toBe(0);
+      expect(await adapter.getGraphTripleCount(GRAPH_B)).toBe(1);
+    });
+  });
+});

--- a/tests/integration/store-factory.test.ts
+++ b/tests/integration/store-factory.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createReadyAdapter, resetAdapterCache } from '../../src/lib/store-factory.js';
+import type { OpenTologyConfig } from '../../src/lib/config.js';
+
+const BASE_CONFIG: OpenTologyConfig = {
+  projectId: 'test',
+  mode: 'embedded',
+  graphUri: 'https://test.org/graph',
+  prefixes: {
+    rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+    ex: 'http://example.org/',
+  },
+};
+
+describe('createReadyAdapter — embedded singleton', () => {
+  beforeEach(() => {
+    resetAdapterCache();
+  });
+
+  it('returns the same adapter instance across calls', async () => {
+    const a1 = await createReadyAdapter(BASE_CONFIG);
+    const a2 = await createReadyAdapter(BASE_CONFIG);
+    expect(a1).toBe(a2);
+  });
+
+  it('data pushed in one call is queryable in the next', async () => {
+    const turtle = `
+      @prefix ex: <http://example.org/> .
+      ex:Alice ex:name "Alice" .
+    `;
+
+    // Call 1: push data
+    const adapter1 = await createReadyAdapter(BASE_CONFIG);
+    await adapter1.insertTurtle(BASE_CONFIG.graphUri, turtle);
+
+    // Call 2: query data (simulates a separate MCP tool call)
+    const adapter2 = await createReadyAdapter(BASE_CONFIG);
+    const result = await adapter2.sparqlQuery(`
+      SELECT ?name WHERE {
+        GRAPH <${BASE_CONFIG.graphUri}> {
+          <http://example.org/Alice> <http://example.org/name> ?name .
+        }
+      }
+    `);
+
+    expect(result.results.bindings).toHaveLength(1);
+    expect(result.results.bindings[0]!['name']!.value).toBe('Alice');
+  });
+
+  it('deletions persist across calls', async () => {
+    const turtle = `
+      @prefix ex: <http://example.org/> .
+      ex:A ex:p ex:B .
+      ex:A ex:p ex:C .
+    `;
+
+    const adapter1 = await createReadyAdapter(BASE_CONFIG);
+    await adapter1.insertTurtle(BASE_CONFIG.graphUri, turtle);
+
+    // Call 2: delete one triple
+    const adapter2 = await createReadyAdapter(BASE_CONFIG);
+    await adapter2.deleteTriples(BASE_CONFIG.graphUri, {
+      turtle: `@prefix ex: <http://example.org/> .\nex:A ex:p ex:B .`,
+    });
+
+    // Call 3: verify deletion persisted
+    const adapter3 = await createReadyAdapter(BASE_CONFIG);
+    const count = await adapter3.getGraphTripleCount(BASE_CONFIG.graphUri);
+    expect(count).toBe(1);
+  });
+
+  it('dropGraph persists across calls', async () => {
+    const turtle = `
+      @prefix ex: <http://example.org/> .
+      ex:X ex:p ex:Y .
+    `;
+
+    const adapter1 = await createReadyAdapter(BASE_CONFIG);
+    await adapter1.insertTurtle(BASE_CONFIG.graphUri, turtle);
+    expect(await adapter1.getGraphTripleCount(BASE_CONFIG.graphUri)).toBe(1);
+
+    // Call 2: drop
+    const adapter2 = await createReadyAdapter(BASE_CONFIG);
+    await adapter2.dropGraph(BASE_CONFIG.graphUri);
+
+    // Call 3: verify empty
+    const adapter3 = await createReadyAdapter(BASE_CONFIG);
+    expect(await adapter3.getGraphTripleCount(BASE_CONFIG.graphUri)).toBe(0);
+  });
+
+  it('resetAdapterCache creates a fresh store', async () => {
+    const adapter1 = await createReadyAdapter(BASE_CONFIG);
+    await adapter1.insertTurtle(BASE_CONFIG.graphUri, `
+      @prefix ex: <http://example.org/> .
+      ex:A ex:p ex:B .
+    `);
+
+    resetAdapterCache();
+
+    const adapter2 = await createReadyAdapter(BASE_CONFIG);
+    expect(adapter2).not.toBe(adapter1);
+    expect(await adapter2.getGraphTripleCount(BASE_CONFIG.graphUri)).toBe(0);
+  });
+});

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect } from 'vitest';
+import { EmbeddedAdapter } from '../../src/lib/embedded-adapter.js';
+import { materializeInferences, clearInferences } from '../../src/lib/reasoner.js';
+
+const GRAPH = 'https://test.org/workflow';
+
+describe('Workflow: push -> infer -> query cycle', () => {
+  it('materializes rdfs:subClassOf inferences and queries superclass instances', async () => {
+    const adapter = new EmbeddedAdapter();
+
+    const ontology = `
+      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+      @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+      @prefix ex: <http://example.org/> .
+      ex:Person rdf:type rdfs:Class .
+      ex:Doctor rdfs:subClassOf ex:Person .
+      ex:Kim rdf:type ex:Doctor .
+      ex:Kim ex:name "Dr. Kim" .
+    `;
+    await adapter.insertTurtle(GRAPH, ontology);
+
+    // Before inference: Kim is only a Doctor
+    const beforeResult = await adapter.sparqlQuery(`
+      SELECT ?s WHERE {
+        GRAPH <${GRAPH}> { ?s a <http://example.org/Person> }
+      }
+    `);
+    expect(beforeResult.results.bindings).toHaveLength(0);
+
+    // Materialize inferences
+    const result = await materializeInferences(adapter, GRAPH);
+    expect(result.inferredCount).toBeGreaterThan(0);
+    expect(result.rules).toHaveProperty('rdfs9');
+
+    // After inference: Kim is also a Person via rdfs9
+    const afterResult = await adapter.sparqlQuery(`
+      SELECT ?s WHERE {
+        GRAPH <${GRAPH}> { ?s a <http://example.org/Person> }
+      }
+    `);
+    expect(afterResult.results.bindings).toHaveLength(1);
+    expect(afterResult.results.bindings[0]!['s']!.value).toBe('http://example.org/Kim');
+  });
+
+  it('clearInferences removes inferred triples', async () => {
+    const adapter = new EmbeddedAdapter();
+
+    const ontology = `
+      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+      @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+      @prefix ex: <http://example.org/> .
+      ex:Doctor rdfs:subClassOf ex:Person .
+      ex:Kim rdf:type ex:Doctor .
+    `;
+    await adapter.insertTurtle(GRAPH, ontology);
+    await materializeInferences(adapter, GRAPH);
+
+    // Kim is a Person after inference
+    let result = await adapter.sparqlQuery(`
+      SELECT ?s WHERE {
+        GRAPH <${GRAPH}> { ?s a <http://example.org/Person> }
+      }
+    `);
+    expect(result.results.bindings).toHaveLength(1);
+
+    // Clear inferences
+    await clearInferences(adapter, GRAPH);
+
+    // Kim is no longer a Person
+    result = await adapter.sparqlQuery(`
+      SELECT ?s WHERE {
+        GRAPH <${GRAPH}> { ?s a <http://example.org/Person> }
+      }
+    `);
+    expect(result.results.bindings).toHaveLength(0);
+  });
+});
+
+describe('Workflow: push --replace behavior', () => {
+  it('drop + re-insert replaces graph contents entirely', async () => {
+    const adapter = new EmbeddedAdapter();
+
+    const v1 = `
+      @prefix ex: <http://example.org/> .
+      ex:A ex:version "1" .
+      ex:A ex:old "data" .
+    `;
+    await adapter.insertTurtle(GRAPH, v1);
+    expect(await adapter.getGraphTripleCount(GRAPH)).toBe(2);
+
+    // Replace: drop then insert V2
+    await adapter.dropGraph(GRAPH);
+
+    const v2 = `
+      @prefix ex: <http://example.org/> .
+      ex:B ex:version "2" .
+    `;
+    await adapter.insertTurtle(GRAPH, v2);
+
+    expect(await adapter.getGraphTripleCount(GRAPH)).toBe(1);
+
+    // Only V2 data present
+    const result = await adapter.sparqlQuery(`
+      SELECT ?s ?p ?o WHERE { GRAPH <${GRAPH}> { ?s ?p ?o } }
+    `);
+    expect(result.results.bindings).toHaveLength(1);
+    expect(result.results.bindings[0]!['s']!.value).toBe('http://example.org/B');
+    expect(result.results.bindings[0]!['o']!.value).toBe('2');
+
+    // V1 data gone
+    const v1Result = await adapter.sparqlQuery(`
+      SELECT ?o WHERE {
+        GRAPH <${GRAPH}> { <http://example.org/A> ?p ?o }
+      }
+    `);
+    expect(v1Result.results.bindings).toHaveLength(0);
+  });
+});
+
+describe('Workflow: diffGraph scenarios', () => {
+  it('diff with superset file shows added triples', async () => {
+    const adapter = new EmbeddedAdapter();
+
+    const subset = `
+      @prefix ex: <http://example.org/> .
+      ex:A ex:p ex:B .
+    `;
+    await adapter.insertTurtle(GRAPH, subset);
+
+    const superset = `
+      @prefix ex: <http://example.org/> .
+      ex:A ex:p ex:B .
+      ex:A ex:p ex:C .
+      ex:A ex:p ex:D .
+    `;
+
+    const diff = await adapter.diffGraph(GRAPH, superset);
+
+    expect(diff.added).toHaveLength(2);
+    expect(diff.removed).toHaveLength(0);
+    expect(diff.unchanged).toBe(1);
+  });
+
+  it('diff with subset file shows removed triples', async () => {
+    const adapter = new EmbeddedAdapter();
+
+    const superset = `
+      @prefix ex: <http://example.org/> .
+      ex:A ex:p ex:B .
+      ex:A ex:p ex:C .
+      ex:A ex:p ex:D .
+    `;
+    await adapter.insertTurtle(GRAPH, superset);
+
+    const subset = `
+      @prefix ex: <http://example.org/> .
+      ex:A ex:p ex:B .
+    `;
+
+    const diff = await adapter.diffGraph(GRAPH, subset);
+
+    expect(diff.added).toHaveLength(0);
+    expect(diff.removed).toHaveLength(2);
+    expect(diff.unchanged).toBe(1);
+  });
+
+  it('diff with identical data shows no changes', async () => {
+    const adapter = new EmbeddedAdapter();
+
+    const turtle = `
+      @prefix ex: <http://example.org/> .
+      ex:A ex:p ex:B .
+      ex:C ex:p ex:D .
+      ex:E ex:p ex:F .
+    `;
+    await adapter.insertTurtle(GRAPH, turtle);
+
+    const diff = await adapter.diffGraph(GRAPH, turtle);
+
+    expect(diff.added).toHaveLength(0);
+    expect(diff.removed).toHaveLength(0);
+    expect(diff.unchanged).toBe(3);
+  });
+});
+
+describe('Workflow: getSchemaOverview full', () => {
+  it('returns complete schema information for rich data', async () => {
+    const adapter = new EmbeddedAdapter();
+
+    const turtle = `
+      @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+      @prefix ex: <http://example.org/> .
+
+      ex:Person rdf:type rdfs:Class .
+      ex:Organization rdf:type rdfs:Class .
+
+      ex:Alice rdf:type ex:Person .
+      ex:Alice ex:name "Alice" .
+      ex:Alice ex:age "30" .
+      ex:Alice ex:worksAt ex:Acme .
+
+      ex:Bob rdf:type ex:Person .
+      ex:Bob ex:name "Bob" .
+
+      ex:Acme rdf:type ex:Organization .
+      ex:Acme ex:name "Acme Corp" .
+    `;
+    await adapter.insertTurtle(GRAPH, turtle);
+
+    const overview = await adapter.getSchemaOverview(GRAPH);
+
+    // Triple count: 2 Class declarations + 3 Alice triples + 1 Alice type +
+    //               1 Bob name + 1 Bob type + 1 Acme name + 1 Acme type = 10
+    expect(overview.tripleCount).toBe(10);
+
+    // Classes used in rdf:type assertions
+    expect(overview.classes).toContain('http://example.org/Person');
+    expect(overview.classes).toContain('http://example.org/Organization');
+    expect(overview.classes).toContain('http://www.w3.org/2000/01/rdf-schema#Class');
+
+    // Properties
+    expect(overview.properties).toContain('http://example.org/name');
+    expect(overview.properties).toContain('http://example.org/age');
+    expect(overview.properties).toContain('http://example.org/worksAt');
+    expect(overview.properties).toContain('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+
+    // Prefixes should be extracted from URIs
+    expect(Object.keys(overview.prefixes).length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- **Bug**: `createReadyAdapter()` created a new `EmbeddedAdapter` on every call, causing data inserted via one MCP tool call to be GC'd before the next
- **Fix**: Module-level singleton cache in `store-factory.ts` — reuses the adapter within the same process, incrementally loads only new tracked files
- **Tests**: 3 new integration test files (embedded-adapter, store-factory, workflows)

## Verification
MCP 서버 재시작 후 5단계 실동작 검증 통과:
1. `opentology_push` → 4 triples 삽입 ✓
2. `opentology_query` → Alice, Bob 2건 반환 ✓
3. `opentology_delete` → Alice 삭제 ✓
4. `opentology_query` → Bob 1건만 반환 ✓
5. `opentology_drop` → 테스트 그래프 정리 ✓

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)