### PR TITLE
feat: add triple count limit to opentology_push

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -16,6 +16,16 @@ import { discoverShapes, validateWithShacl, hasShapes } from '../lib/shacl.js';
 import { materializeInferences, clearInferences } from '../lib/reasoner.js';
 import type { InferenceResult } from '../lib/reasoner.js';
 
+export const MAX_TRIPLES_PER_PUSH = 100;
+
+export function assertTripleLimit(tripleCount: number): void {
+  if (tripleCount > MAX_TRIPLES_PER_PUSH) {
+    throw new Error(
+      `Too many triples (${tripleCount}). Maximum is ${MAX_TRIPLES_PER_PUSH} per push. Split your data into smaller batches.`
+    );
+  }
+}
+
 function resolveConfig(params: { endpoint?: string; graphUri?: string; graph?: string }): { config: OpenTologyConfig; graphUri: string } {
   try {
     const config = loadConfig();
@@ -77,6 +87,8 @@ async function handlePush(args: Record<string, unknown>): Promise<unknown> {
   if (!validation.valid) {
     throw new Error(`Invalid Turtle: ${validation.error}`);
   }
+
+  assertTripleLimit(validation.tripleCount!);
 
   // Auto-validate against SHACL when shapes exist (unless explicitly false)
   if (shacl !== false && hasShapes()) {
@@ -449,7 +461,7 @@ export async function startMcpServer(): Promise<void> {
       },
       {
         name: 'opentology_push',
-        description: 'Validate and insert Turtle (RDF) triples into the project graph. Validates syntax first, then pushes to the SPARQL endpoint. Auto-validates against SHACL shapes when shapes/ directory exists. Returns success status and triple count.',
+        description: 'Validate and insert Turtle (RDF) triples into the project graph. Validates syntax first, then pushes to the SPARQL endpoint. Auto-validates against SHACL shapes when shapes/ directory exists. Returns success status and triple count. IMPORTANT: Maximum 100 triples per call. For larger datasets, split into multiple pushes of 20-50 triples each.',
         inputSchema: {
           type: 'object' as const,
           properties: {

--- a/tests/unit/triple-limit.test.ts
+++ b/tests/unit/triple-limit.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { assertTripleLimit, MAX_TRIPLES_PER_PUSH } from '../../src/mcp/server.js';
+
+describe('assertTripleLimit', () => {
+  it('allows triples within the limit', () => {
+    expect(() => assertTripleLimit(1)).not.toThrow();
+    expect(() => assertTripleLimit(50)).not.toThrow();
+    expect(() => assertTripleLimit(MAX_TRIPLES_PER_PUSH)).not.toThrow();
+  });
+
+  it('rejects triples exceeding the limit', () => {
+    expect(() => assertTripleLimit(MAX_TRIPLES_PER_PUSH + 1)).toThrow(
+      /Too many triples/
+    );
+    expect(() => assertTripleLimit(500)).toThrow(
+      /Split your data into smaller batches/
+    );
+  });
+
+  it('includes the count in the error message', () => {
+    expect(() => assertTripleLimit(150)).toThrow('Too many triples (150)');
+  });
+
+  it('MAX_TRIPLES_PER_PUSH is 100', () => {
+    expect(MAX_TRIPLES_PER_PUSH).toBe(100);
+  });
+});


### PR DESCRIPTION
## Summary
- **Server-side limit**: Max 100 triples per `opentology_push` call, clear error message guiding LLM to split into batches
- **Description hint**: Tool description updated with recommended 20-50 triples per call
- **Tests**: 4 new unit tests for `assertTripleLimit`

## Test plan
- [x] Build passes
- [x] 46/46 tests pass (42 existing + 4 new)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)