### PR TITLE
feat: generate slash commands on context init

### DIFF
--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -7,6 +7,7 @@ import { createReadyAdapter } from '../lib/store-factory.js';
 import { OTX_BOOTSTRAP_TURTLE } from '../templates/otx-ontology.js';
 import { generateContextSection, updateClaudeMd } from '../templates/claude-md-context.js';
 import { generateHookScript } from '../templates/session-start-hook.js';
+import { generateSlashCommands } from '../templates/slash-commands.js';
 
 export interface ContextLoadOutput {
   projectId: string;
@@ -130,7 +131,25 @@ export function registerContext(program: Command): void {
           }
         }
 
-        // Step 5: Save config LAST (atomic commit point)
+        // Step 5: Generate slash commands
+        const commandsDir = join(process.cwd(), '.claude', 'commands');
+        const slashCommands = generateSlashCommands();
+        let slashCreated = 0;
+        mkdirSync(commandsDir, { recursive: true });
+        for (const cmd of slashCommands) {
+          const cmdPath = join(commandsDir, cmd.filename);
+          if (!existsSync(cmdPath) || opts.force) {
+            writeFileSync(cmdPath, cmd.content, 'utf-8');
+            slashCreated++;
+          }
+        }
+        if (slashCreated > 0) {
+          console.log(pc.green(`  Generated ${slashCreated} slash commands in .claude/commands/`));
+        } else {
+          console.log(pc.dim('  Slash commands already exist — skipped'));
+        }
+
+        // Step 6: Save config LAST (atomic commit point)
         saveConfig(config);
 
         // Print hook registration instructions

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -20,6 +20,7 @@ import { join } from 'node:path';
 import { OTX_BOOTSTRAP_TURTLE } from '../templates/otx-ontology.js';
 import { generateContextSection, updateClaudeMd } from '../templates/claude-md-context.js';
 import { generateHookScript } from '../templates/session-start-hook.js';
+import { generateSlashCommands } from '../templates/slash-commands.js';
 import type { ContextLoadOutput } from '../commands/context.js';
 
 export const MAX_TRIPLES_PER_PUSH = 100;
@@ -424,6 +425,22 @@ async function handleContextInit(args: Record<string, unknown>): Promise<unknown
   } else {
     updateClaudeMd(claudeMdPath, section);
     actions.push('Updated CLAUDE.md context section');
+  }
+
+  // Generate slash commands
+  const commandsDir = join(process.cwd(), '.claude', 'commands');
+  const slashCommands = generateSlashCommands();
+  mkdirSync(commandsDir, { recursive: true });
+  let slashCreated = 0;
+  for (const cmd of slashCommands) {
+    const cmdPath = join(commandsDir, cmd.filename);
+    if (!existsSync(cmdPath) || force) {
+      writeFileSync(cmdPath, cmd.content, 'utf-8');
+      slashCreated++;
+    }
+  }
+  if (slashCreated > 0) {
+    actions.push(`Generated ${slashCreated} slash commands in .claude/commands/`);
   }
 
   saveConfig(config);

--- a/src/templates/slash-commands.ts
+++ b/src/templates/slash-commands.ts
@@ -1,0 +1,58 @@
+export interface SlashCommand {
+  filename: string;
+  content: string;
+}
+
+export function generateSlashCommands(): SlashCommand[] {
+  return [
+    {
+      filename: 'opentology-context-init.md',
+      content: `Use the opentology_context_init MCP tool to initialize the project context graph.
+
+After initialization, report what was created (graphs, hook script, CLAUDE.md).
+Then show the hook JSON snippet the user needs to add to .claude/settings.json.
+`,
+    },
+    {
+      filename: 'opentology-context-load.md',
+      content: `Use the opentology_context_load MCP tool to load the current project context.
+
+Display the results in a readable format:
+- Recent sessions with dates and next todos
+- Open issues
+- Recent decisions
+
+If context is not initialized, suggest running /opentology-context-init first.
+`,
+    },
+    {
+      filename: 'opentology-context-save.md',
+      content: `Save a session summary to the OpenTology sessions graph.
+
+Ask the user what was accomplished in this session, or summarize the conversation so far.
+
+Then use opentology_push to insert a session record:
+
+\`\`\`turtle
+@prefix otx: <https://opentology.dev/vocab#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:session:{today's date}> a otx:Session ;
+    otx:title "{session summary title}" ;
+    otx:date "{YYYY-MM-DD}"^^xsd:date ;
+    otx:body "{what was done}" ;
+    otx:nextTodo "{what to do next}" .
+\`\`\`
+
+Push to the sessions graph (use graph name "sessions").
+`,
+    },
+    {
+      filename: 'opentology-context-status.md',
+      content: `Use the opentology_context_status MCP tool to check the project context initialization status.
+
+Display the results clearly: whether context is initialized, graph triple counts, hook presence, and CLAUDE.md status.
+`,
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- `context init`이 `.claude/commands/`에 4개 슬래시 커맨드 자동 생성
- `/opentology-context-init`, `/opentology-context-load`, `/opentology-context-save`, `/opentology-context-status`
- CLI와 MCP 도구 모두에서 동작

## Test plan
- [x] Build passes
- [x] 57/57 tests pass
- [x] E2E: 4 slash command files created in .claude/commands/

🤖 Generated with [Claude Code](https://claude.com/claude-code)