### PR TITLE
feat: expose slash commands as MCP prompts

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -5,6 +5,8 @@ import {
   CallToolRequestSchema,
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
+  ListPromptsRequestSchema,
+  GetPromptRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { loadConfig, saveConfig, configExists, resolveGraphUri } from '../lib/config.js';
 import type { OpenTologyConfig } from '../lib/config.js';
@@ -588,7 +590,7 @@ async function handleContextStatus(): Promise<unknown> {
 export async function startMcpServer(): Promise<void> {
   const server = new Server(
     { name: 'opentology', version: '0.1.0' },
-    { capabilities: { tools: {}, resources: {} } }
+    { capabilities: { tools: {}, resources: {}, prompts: {} } }
   );
 
   server.setRequestHandler(ListResourcesRequestSchema, async () => ({
@@ -633,6 +635,36 @@ export async function startMcpServer(): Promise<void> {
     }
 
     throw new Error(`Unknown resource: ${uri}`);
+  });
+
+  // --- MCP Prompts (slash commands) ---
+  const promptDefinitions = generateSlashCommands().map((cmd) => ({
+    name: cmd.filename.replace(/\.md$/, ''),
+    description: cmd.content.split('\n')[0],
+    content: cmd.content,
+  }));
+
+  server.setRequestHandler(ListPromptsRequestSchema, async () => ({
+    prompts: promptDefinitions.map(({ name, description }) => ({
+      name,
+      description,
+    })),
+  }));
+
+  server.setRequestHandler(GetPromptRequestSchema, async (request) => {
+    const { name } = request.params;
+    const prompt = promptDefinitions.find((p) => p.name === name);
+    if (!prompt) {
+      throw new Error(`Unknown prompt: ${name}`);
+    }
+    return {
+      messages: [
+        {
+          role: 'user' as const,
+          content: { type: 'text' as const, text: prompt.content },
+        },
+      ],
+    };
   });
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({

--- a/tests/unit/mcp-prompts.test.ts
+++ b/tests/unit/mcp-prompts.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { generateSlashCommands } from '../../src/templates/slash-commands.js';
+
+describe('MCP prompts from slash commands', () => {
+  const commands = generateSlashCommands();
+
+  it('generates at least one slash command', () => {
+    expect(commands.length).toBeGreaterThan(0);
+  });
+
+  it('each command has filename and content', () => {
+    for (const cmd of commands) {
+      expect(cmd.filename).toBeTruthy();
+      expect(cmd.content).toBeTruthy();
+    }
+  });
+
+  it('filenames end with .md', () => {
+    for (const cmd of commands) {
+      expect(cmd.filename).toMatch(/\.md$/);
+    }
+  });
+
+  it('prompt names are valid after stripping .md', () => {
+    for (const cmd of commands) {
+      const name = cmd.filename.replace(/\.md$/, '');
+      expect(name).toMatch(/^[a-z0-9-]+$/);
+      expect(name.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('generates expected prompt names', () => {
+    const names = commands.map((c) => c.filename.replace(/\.md$/, ''));
+    expect(names).toContain('opentology-context-init');
+    expect(names).toContain('opentology-context-load');
+    expect(names).toContain('opentology-context-save');
+    expect(names).toContain('opentology-context-status');
+  });
+});


### PR DESCRIPTION
## Summary
- MCP `prompts` capability 추가로 서버 연결만으로 슬래시 커맨드 자동 노출
- `ListPromptsRequestSchema` / `GetPromptRequestSchema` 핸들러 구현
- 기존 `slash-commands.ts` 템플릿을 MCP prompts로 변환
- `.claude/commands/` 파일 생성 없이 바로 사용 가능

## Test plan
- [x] 빌드 통과 (`npm run build`)
- [x] 전체 테스트 통과 (62/62)
- [x] MCP prompts 유닛 테스트 추가 (`tests/unit/mcp-prompts.test.ts`)

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)