### PR TITLE
feat: extract dependency graph triples from codebase scan

### DIFF
--- a/src/lib/codebase-scanner.ts
+++ b/src/lib/codebase-scanner.ts
@@ -11,6 +11,16 @@ export interface DirectoryNode {
   children?: DirectoryNode[];
 }
 
+export interface DependencyEdge {
+  from: string;
+  to: string;
+}
+
+export interface DependencyGraph {
+  modules: string[];
+  edges: DependencyEdge[];
+}
+
 export interface CodebaseSnapshot {
   packageJson: {
     name?: string;
@@ -33,6 +43,7 @@ export interface CodebaseSnapshot {
     content: string;
   }>;
   detectedImports: string[];
+  dependencyGraph: DependencyGraph | null;
   readme: string | null;
   truncated?: boolean;
 }
@@ -200,6 +211,95 @@ async function detectImports(rootDir: string, filePaths: string[]): Promise<stri
   return [...imports].sort();
 }
 
+async function collectSourceFiles(rootDir: string, dir: string, gitFiles: Set<string> | null): Promise<string[]> {
+  const results: string[] = [];
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return results;
+  }
+  for (const entry of entries) {
+    const relPath = relative(rootDir, join(dir, entry.name));
+    if (isExcluded(entry.name, gitFiles, relPath)) continue;
+    if (entry.isDirectory()) {
+      results.push(...await collectSourceFiles(rootDir, join(dir, entry.name), gitFiles));
+    } else if (entry.isFile() && /\.[tj]sx?$/.test(entry.name)) {
+      results.push(relPath);
+    }
+  }
+  return results;
+}
+
+const LOCAL_IMPORT_REGEX = /(?:import|export)\s+(?:(?:type\s+)?(?:\{[^}]*\}|[^'";\n]+)\s+from\s+)?['"](\.\.?\/[^'"]+)['"]/g;
+
+function normalizeImportPath(fromFile: string, importPath: string): string | null {
+  const fromDir = fromFile.includes('/') ? fromFile.substring(0, fromFile.lastIndexOf('/')) : '.';
+  const parts = (fromDir === '.' ? importPath : `${fromDir}/${importPath}`).split('/');
+  const resolved: string[] = [];
+  for (const part of parts) {
+    if (part === '.') continue;
+    if (part === '..') { resolved.pop(); continue; }
+    resolved.push(part);
+  }
+  let result = resolved.join('/');
+  // Strip file extension for module name
+  result = result.replace(/\.[tj]sx?$/, '').replace(/\.js$/, '');
+  return result || null;
+}
+
+export async function extractDependencyGraph(rootDir: string, gitFiles: Set<string> | null): Promise<DependencyGraph> {
+  const sourceFiles = await collectSourceFiles(rootDir, rootDir, gitFiles);
+  const moduleSet = new Set<string>();
+  const edges: DependencyEdge[] = [];
+
+  for (const filePath of sourceFiles) {
+    const moduleName = filePath.replace(/\.[tj]sx?$/, '');
+    moduleSet.add(moduleName);
+
+    let content: string;
+    try {
+      content = await readFile(join(rootDir, filePath), 'utf-8');
+    } catch {
+      continue;
+    }
+
+    LOCAL_IMPORT_REGEX.lastIndex = 0;
+    let match;
+    while ((match = LOCAL_IMPORT_REGEX.exec(content)) !== null) {
+      const importPath = match[1];
+      const resolved = normalizeImportPath(filePath, importPath);
+      if (resolved) {
+        // Find the actual file (could be .ts, .tsx, /index.ts, etc.)
+        const target = sourceFiles.find(f => {
+          const noExt = f.replace(/\.[tj]sx?$/, '');
+          return noExt === resolved || noExt === `${resolved}/index`;
+        });
+        if (target) {
+          const targetModule = target.replace(/\.[tj]sx?$/, '');
+          if (targetModule !== moduleName) {
+            edges.push({ from: moduleName, to: targetModule });
+          }
+        }
+      }
+    }
+  }
+
+  // Deduplicate edges
+  const seen = new Set<string>();
+  const uniqueEdges = edges.filter(e => {
+    const key = `${e.from}->${e.to}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+
+  return {
+    modules: [...moduleSet].sort(),
+    edges: uniqueEdges,
+  };
+}
+
 function byteLength(obj: unknown): number {
   return Buffer.byteLength(JSON.stringify(obj), 'utf-8');
 }
@@ -239,6 +339,12 @@ function applyTruncation(snapshot: CodebaseSnapshot, maxBytes: number): Codebase
   // Stage 4: Drop detectedImports
   if (byteLength(snapshot) > maxBytes) {
     snapshot.detectedImports = [];
+    snapshot.truncated = true;
+  }
+
+  // Stage 5: Drop dependencyGraph
+  if (byteLength(snapshot) > maxBytes) {
+    snapshot.dependencyGraph = null;
     snapshot.truncated = true;
   }
 
@@ -290,6 +396,9 @@ export async function scanCodebase(rootDir: string, maxBytes: number = DEFAULT_M
   // Detect imports
   const detectedImports = await detectImports(rootDir, entryPointPaths);
 
+  // Extract dependency graph
+  const dependencyGraph = await extractDependencyGraph(rootDir, gitFiles);
+
   // Read README
   const readme = await readTruncatedFile(join(rootDir, 'README.md'), MAX_README_LINES);
 
@@ -299,6 +408,7 @@ export async function scanCodebase(rootDir: string, maxBytes: number = DEFAULT_M
     directoryTree,
     entryPoints,
     detectedImports,
+    dependencyGraph,
     readme,
   };
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -381,7 +381,7 @@ async function handleContextScan(args: Record<string, unknown>): Promise<unknown
   const snapshot = await scanCodebase(process.cwd(), maxBytes);
   return {
     codebaseSnapshot: snapshot,
-    _hint: 'Analyze codebaseSnapshot and push Knowledge triples via opentology_push. Create otx:Project and otx:Knowledge resources in the context graph.',
+    _hint: 'Analyze codebaseSnapshot and push Knowledge/Module triples via opentology_push. Create otx:Project, otx:Knowledge, and otx:Module (with otx:dependsOn edges from dependencyGraph) resources in the context graph.',
   };
 }
 
@@ -996,7 +996,7 @@ export async function startMcpServer(): Promise<void> {
       },
       {
         name: 'opentology_context_scan',
-        description: 'Scan the current project codebase and return a structured snapshot (package.json, directory tree, entry points, detected frameworks). Use the snapshot to create Knowledge triples via opentology_push. Can be called independently of context_init.',
+        description: 'Scan the current project codebase and return a structured snapshot (package.json, directory tree, entry points, detected frameworks, dependency graph). Includes module dependency edges extracted from import statements. Use the snapshot to create Knowledge and Module triples via opentology_push. Can be called independently of context_init.',
         inputSchema: {
           type: 'object' as const,
           properties: {

--- a/src/templates/otx-ontology.ts
+++ b/src/templates/otx-ontology.ts
@@ -10,6 +10,7 @@ otx:Issue a owl:Class .
 otx:Knowledge a owl:Class .
 otx:Session a owl:Class .
 otx:Pattern a owl:Class .
+otx:Module a owl:Class .
 
 otx:title a owl:DatatypeProperty ; rdfs:range xsd:string .
 otx:date a owl:DatatypeProperty ; rdfs:range xsd:date .
@@ -21,6 +22,7 @@ otx:solution a owl:DatatypeProperty ; rdfs:range xsd:string .
 otx:nextTodo a owl:DatatypeProperty ; rdfs:range xsd:string .
 otx:relatedTo a owl:ObjectProperty .
 otx:project a owl:ObjectProperty .
+otx:dependsOn a owl:ObjectProperty ; rdfs:domain otx:Module ; rdfs:range otx:Module .
 otx:stack a owl:DatatypeProperty ; rdfs:range xsd:string .
 otx:alternative a owl:DatatypeProperty ; rdfs:range xsd:string .
 `;

--- a/tests/unit/codebase-scanner.test.ts
+++ b/tests/unit/codebase-scanner.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { scanCodebase } from '../../src/lib/codebase-scanner.js';
+import { scanCodebase, extractDependencyGraph } from '../../src/lib/codebase-scanner.js';
 import type { CodebaseSnapshot, DirectoryNode } from '../../src/lib/codebase-scanner.js';
 
 let tempDir: string;
@@ -146,6 +146,67 @@ describe('codebase-scanner', () => {
       expect(names).not.toContain('node_modules');
       expect(names).not.toContain('dist');
       expect(names).toContain('src');
+    });
+  });
+
+  describe('dependency graph extraction', () => {
+    it('extracts local import edges between modules', async () => {
+      mkdirSync(join(tempDir, 'src', 'lib'), { recursive: true });
+      writeFileSync(join(tempDir, 'src', 'index.ts'),
+        `import { foo } from './lib/config.js';\nimport { bar } from './lib/store.js';\n`);
+      writeFileSync(join(tempDir, 'src', 'lib', 'config.ts'), `export const foo = 1;\n`);
+      writeFileSync(join(tempDir, 'src', 'lib', 'store.ts'),
+        `import { foo } from './config.js';\nexport const bar = foo;\n`);
+
+      const graph = await extractDependencyGraph(tempDir, null);
+      expect(graph.modules).toContain('src/index');
+      expect(graph.modules).toContain('src/lib/config');
+      expect(graph.modules).toContain('src/lib/store');
+      expect(graph.edges).toContainEqual({ from: 'src/index', to: 'src/lib/config' });
+      expect(graph.edges).toContainEqual({ from: 'src/index', to: 'src/lib/store' });
+      expect(graph.edges).toContainEqual({ from: 'src/lib/store', to: 'src/lib/config' });
+    });
+
+    it('deduplicates edges from multiple imports of same module', async () => {
+      mkdirSync(join(tempDir, 'src'), { recursive: true });
+      writeFileSync(join(tempDir, 'src', 'a.ts'),
+        `import { x } from './b.js';\nimport { y } from './b.js';\n`);
+      writeFileSync(join(tempDir, 'src', 'b.ts'), `export const x = 1;\nexport const y = 2;\n`);
+
+      const graph = await extractDependencyGraph(tempDir, null);
+      const aToB = graph.edges.filter(e => e.from === 'src/a' && e.to === 'src/b');
+      expect(aToB).toHaveLength(1);
+    });
+
+    it('ignores external (npm) imports', async () => {
+      mkdirSync(join(tempDir, 'src'), { recursive: true });
+      writeFileSync(join(tempDir, 'src', 'index.ts'),
+        `import { Command } from 'commander';\nimport express from 'express';\n`);
+
+      const graph = await extractDependencyGraph(tempDir, null);
+      expect(graph.edges).toHaveLength(0);
+    });
+
+    it('handles re-exports', async () => {
+      mkdirSync(join(tempDir, 'src'), { recursive: true });
+      writeFileSync(join(tempDir, 'src', 'index.ts'),
+        `export { foo } from './util.js';\n`);
+      writeFileSync(join(tempDir, 'src', 'util.ts'), `export const foo = 1;\n`);
+
+      const graph = await extractDependencyGraph(tempDir, null);
+      expect(graph.edges).toContainEqual({ from: 'src/index', to: 'src/util' });
+    });
+
+    it('is included in scanCodebase snapshot', async () => {
+      mkdirSync(join(tempDir, 'src'), { recursive: true });
+      writeFileSync(join(tempDir, 'src', 'a.ts'), `import { b } from './b.js';\n`);
+      writeFileSync(join(tempDir, 'src', 'b.ts'), `export const b = 1;\n`);
+      writeFileSync(join(tempDir, 'package.json'), '{}');
+
+      const snapshot = await scanCodebase(tempDir);
+      expect(snapshot.dependencyGraph).not.toBeNull();
+      expect(snapshot.dependencyGraph!.modules.length).toBeGreaterThan(0);
+      expect(snapshot.dependencyGraph!.edges.length).toBeGreaterThan(0);
     });
   });
 


### PR DESCRIPTION
## Summary

- `context_scan`이 TypeScript/JavaScript import 문을 파싱하여 모듈 간 의존성 그래프(`dependencyGraph`)를 자동 추출
- `otx:Module` 클래스 + `otx:dependsOn` 프로퍼티로 온톨로지 확장
- SPARQL property path(`otx:dependsOn+`)로 전이적 영향 범위 분석 가능

### Example query
```sparql
SELECT ?affected WHERE {
    ?affected otx:dependsOn+ <urn:module:src/lib/store-factory> .
}
```

### Changes
- `src/lib/codebase-scanner.ts` — `extractDependencyGraph()`, `DependencyGraph` type
- `src/templates/otx-ontology.ts` — `otx:Module`, `otx:dependsOn`
- `src/mcp/server.ts` — updated tool description/hint
- `tests/unit/codebase-scanner.test.ts` — 5 new tests

### Dogfooding result (this repo)
- 45 modules, 85 dependency edges detected

## Test plan
- [x] Build passes (`npm run build`)
- [x] All 75 tests pass (`npm test`)
- [x] Verified on actual codebase: 45 modules, 85 edges

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)