### PR TITLE
feat: auto-push Module triples on context_init with fallback guidance

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -381,7 +381,9 @@ async function handleContextScan(args: Record<string, unknown>): Promise<unknown
   const snapshot = await scanCodebase(process.cwd(), maxBytes);
   return {
     codebaseSnapshot: snapshot,
-    _hint: 'Analyze codebaseSnapshot and push Knowledge/Module triples via opentology_push. Create otx:Project, otx:Knowledge, and otx:Module (with otx:dependsOn edges from dependencyGraph) resources in the context graph.',
+    _hint: snapshot.dependencyGraph && snapshot.dependencyGraph.modules.length > 0
+      ? 'Analyze codebaseSnapshot and push Knowledge triples via opentology_push. Module dependency triples (otx:Module + otx:dependsOn) are available in dependencyGraph — push them to the context graph as-is.'
+      : 'Analyze codebaseSnapshot and push Knowledge triples via opentology_push. No dependency graph was auto-extracted (non-JS/TS project or parsing issue). Inspect key source files manually and push otx:Module + otx:dependsOn triples for the important modules you identify.',
   };
 }
 
@@ -457,12 +459,40 @@ async function handleContextInit(args: Record<string, unknown>): Promise<unknown
 
   saveConfig(config);
 
+  // Auto-push Module triples from dependency graph
+  let moduleStats: { modules: number; edges: number } | null = null;
+  try {
+    const snapshot = await scanCodebase(process.cwd());
+    if (snapshot.dependencyGraph && snapshot.dependencyGraph.modules.length > 0) {
+      const dg = snapshot.dependencyGraph;
+      const adapter = await createReadyAdapter(config);
+      const sparqlTriples: string[] = [];
+      for (const mod of dg.modules) {
+        sparqlTriples.push(`<urn:module:${mod}> a <https://opentology.dev/vocab#Module> .`);
+      }
+      for (const edge of dg.edges) {
+        sparqlTriples.push(`<urn:module:${edge.from}> <https://opentology.dev/vocab#dependsOn> <urn:module:${edge.to}> .`);
+      }
+      await adapter.sparqlUpdate(`INSERT DATA { GRAPH <${contextUri}> {\n${sparqlTriples.join('\n')}\n} }`);
+      moduleStats = { modules: dg.modules.length, edges: dg.edges.length };
+      actions.push(`Pushed ${dg.modules.length} Module triples with ${dg.edges.length} dependsOn edges`);
+    }
+  } catch {
+    // Non-fatal: dependency graph push is best-effort
+  }
+
+  const dependencyHint = moduleStats
+    ? `Dependency graph pushed: ${moduleStats.modules} modules, ${moduleStats.edges} edges. Query with: SELECT ?affected WHERE { ?affected otx:dependsOn+ <urn:module:...> }`
+    : 'No dependency graph auto-extracted (non-JS/TS project or no local imports found). Inspect key source files and manually push otx:Module + otx:dependsOn triples for important modules.';
+
   return {
     success: true,
     projectId: config.projectId,
     contextGraph: contextUri,
     sessionsGraph: sessionsUri,
     actions,
+    moduleStats,
+    dependencyHint,
     hookSnippet: {
       hooks: {
         SessionStart: [{

--- a/src/templates/session-start-hook.ts
+++ b/src/templates/session-start-hook.ts
@@ -63,6 +63,8 @@ function formatOutput(data) {
   }
 
   lines.push('---');
+  lines.push('Dependency graph (otx:Module + otx:dependsOn) is available in the context graph.');
+  lines.push('If significant code changes occurred since last scan, consider running opentology_context_scan to update dependency triples.');
   lines.push('Reminder: At session end, push a session summary using opentology_push to the sessions graph.');
 
   return lines.join('\\n');


### PR DESCRIPTION
## Summary

- `context_init` 시 JS/TS 프로젝트면 dependency graph를 자동으로 `otx:Module` + `otx:dependsOn` 트리플로 푸시
- 자동 추출 실패 시 (non-JS/TS 등) LLM에게 핵심 모듈을 직접 파악해서 푸시하라고 안내 (graceful degradation)
- `context_scan` 힌트도 dependency graph 유무에 따라 분기
- SessionStart 훅에 의존성 그래프 존재 안내 + 업데이트 제안 문구 추가

## Changes
- `src/mcp/server.ts` — `handleContextInit`에 auto-push 로직, `handleContextScan` 힌트 분기
- `src/templates/session-start-hook.ts` — dependency graph 안내 추가

## Test plan
- [x] Build passes
- [x] All 75 tests pass
- [x] Auto-push는 best-effort (실패해도 init 성공)

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)