### PR TITLE
feat: add symbol-level deep-scan to context_scan

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "opentology",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opentology",
-      "version": "0.1.0",
-      "license": "ISC",
+      "version": "0.1.1",
+      "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "commander": "^14.0.3",
@@ -23,9 +23,21 @@
       "devDependencies": {
         "@types/n3": "^1.26.1",
         "@types/node": "^25.5.0",
+        "ts-morph": "^27.0.2",
         "ts-node": "^10.9.2",
         "typescript": "^6.0.2",
         "vitest": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "ts-morph": ">=21.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ts-morph": {
+          "optional": true
+        }
       }
     },
     "node_modules/@bergos/jsonparse": {
@@ -4869,6 +4881,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@ts-morph/common": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.28.1.tgz",
+      "integrity": "sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^10.0.1",
+        "path-browserify": "^1.0.1",
+        "tinyglobby": "^0.2.14"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
@@ -5311,6 +5335,16 @@
         "asynciterator": "^3.9.0"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -5362,6 +5396,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/buffer": {
@@ -5458,6 +5505,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/code-block-writer": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
+      "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/color": {
       "version": "5.0.3",
@@ -7065,6 +7119,22 @@
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
       "license": "ISC"
     },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -7252,6 +7322,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -8412,6 +8489,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/ts-morph": {
+      "version": "27.0.2",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-27.0.2.tgz",
+      "integrity": "sha512-fhUhgeljcrdZ+9DZND1De1029PrE+cMkIP7ooqkLRTrRLTqcki2AstsyJm0vRNbTbVCNJ0idGlbBrfqc7/nA8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ts-morph/common": "~0.28.1",
+        "code-block-writer": "^13.0.3"
       }
     },
     "node_modules/ts-node": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentology",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "CLI-managed RDF/SPARQL infrastructure — Supabase for RDF",
   "type": "module",
   "bin": {
@@ -30,7 +30,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Younkyum/opentology.git"
+    "url": "git+https://github.com/Younkyum/opentology.git"
   },
   "homepage": "https://github.com/Younkyum/opentology#readme",
   "bugs": {
@@ -48,9 +48,18 @@
     "rdf-ext": "^2.6.0",
     "shacl-engine": "^1.1.0"
   },
+  "peerDependencies": {
+    "ts-morph": ">=21.0.0"
+  },
+  "peerDependenciesMeta": {
+    "ts-morph": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@types/n3": "^1.26.1",
     "@types/node": "^25.5.0",
+    "ts-morph": "^27.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^6.0.2",
     "vitest": "^4.1.2"

--- a/src/lib/deep-scan-triples.ts
+++ b/src/lib/deep-scan-triples.ts
@@ -1,0 +1,161 @@
+/**
+ * Converts DeepScanResult into OTX-compliant SPARQL INSERT DATA triples
+ * with batched insert and scoped delete-then-insert strategy.
+ */
+
+import type { DeepScanResult } from './deep-scanner.js';
+
+const OTX = 'https://opentology.dev/vocab#';
+
+function encodeSegment(s: string): string {
+  return encodeURIComponent(s);
+}
+
+function symbolUri(filePath: string, kind: string, name: string): string {
+  return `urn:symbol:${encodeSegment(filePath)}/${encodeSegment(kind)}/${encodeSegment(name)}`;
+}
+
+function moduleUri(filePath: string): string {
+  return `urn:module:${filePath}`;
+}
+
+function esc(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+// ── Triple generation ───────────────────────────────────────────
+
+export function generateSymbolTriples(result: DeepScanResult): string[] {
+  const triples: string[] = [];
+
+  for (const cls of result.classes) {
+    const uri = symbolUri(cls.filePath, 'class', cls.name);
+    triples.push(`<${uri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <${OTX}Class> .`);
+    triples.push(`<${uri}> <${OTX}title> "${esc(cls.name)}" .`);
+    triples.push(`<${uri}> <${OTX}definedIn> <${moduleUri(cls.filePath)}> .`);
+
+    if (cls.baseClass) {
+      // baseClass is already a qualified path like "src/lib/foo/class/Bar"
+      const parts = cls.baseClass.split('/');
+      const baseName = parts.pop()!;
+      const baseKind = parts.pop()!;
+      const basePath = parts.join('/');
+      const baseUri = symbolUri(basePath, baseKind, baseName);
+      triples.push(`<${uri}> <${OTX}extends> <${baseUri}> .`);
+    }
+
+    for (const iface of cls.interfaces) {
+      // interface is already qualified like "src/lib/foo/interface/Bar"
+      const parts = iface.split('/');
+      const ifaceName = parts.pop()!;
+      const ifaceKind = parts.pop()!;
+      const ifacePath = parts.join('/');
+      const ifaceUri = symbolUri(ifacePath, ifaceKind, ifaceName);
+      triples.push(`<${uri}> <${OTX}implements> <${ifaceUri}> .`);
+    }
+
+    for (const method of cls.methods) {
+      const methodUri = symbolUri(cls.filePath, 'method', `${cls.name}.${method.name}`);
+      triples.push(`<${methodUri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <${OTX}Method> .`);
+      triples.push(`<${methodUri}> <${OTX}title> "${esc(method.name)}" .`);
+      triples.push(`<${methodUri}> <${OTX}definedIn> <${moduleUri(cls.filePath)}> .`);
+      triples.push(`<${uri}> <${OTX}hasMethod> <${methodUri}> .`);
+      if (method.returnType && method.returnType !== 'void') {
+        triples.push(`<${methodUri}> <${OTX}returns> "${esc(method.returnType)}" .`);
+      }
+      for (const p of method.parameters) {
+        triples.push(`<${methodUri}> <${OTX}paramType> "${esc(p.name)}: ${esc(p.type)}" .`);
+      }
+    }
+  }
+
+  for (const iface of result.interfaces) {
+    const uri = symbolUri(iface.filePath, 'interface', iface.name);
+    triples.push(`<${uri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <${OTX}Interface> .`);
+    triples.push(`<${uri}> <${OTX}title> "${esc(iface.name)}" .`);
+    triples.push(`<${uri}> <${OTX}definedIn> <${moduleUri(iface.filePath)}> .`);
+
+    for (const ext of iface.extends) {
+      // Interface extends are just names (not fully qualified) for now
+      triples.push(`<${uri}> <${OTX}extends> "${esc(ext)}" .`);
+    }
+  }
+
+  for (const fn of result.functions) {
+    const uri = symbolUri(fn.filePath, 'function', fn.name);
+    triples.push(`<${uri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <${OTX}Function> .`);
+    triples.push(`<${uri}> <${OTX}title> "${esc(fn.name)}" .`);
+    triples.push(`<${uri}> <${OTX}definedIn> <${moduleUri(fn.filePath)}> .`);
+    if (fn.returnType && fn.returnType !== 'void') {
+      triples.push(`<${uri}> <${OTX}returns> "${esc(fn.returnType)}" .`);
+    }
+  }
+
+  for (const call of result.methodCalls) {
+    const callerParts = call.caller.split('.');
+    const calleeParts = call.callee.split('.');
+    // Method calls reference by class.method pattern — generate a simple triple
+    triples.push(`<urn:call:${encodeSegment(call.caller)}> <${OTX}calls> <urn:call:${encodeSegment(call.callee)}> .`);
+    // Store caller/callee names for queryability
+    triples.push(`<urn:call:${encodeSegment(call.caller)}> <${OTX}title> "${esc(call.caller)}" .`);
+    triples.push(`<urn:call:${encodeSegment(call.callee)}> <${OTX}title> "${esc(call.callee)}" .`);
+  }
+
+  return triples;
+}
+
+// ── Batching ────────────────────────────────────────────────────
+
+export function batchTriples(triples: string[], batchSize = 100): string[][] {
+  const batches: string[][] = [];
+  for (let i = 0; i < triples.length; i += batchSize) {
+    batches.push(triples.slice(i, i + batchSize));
+  }
+  return batches;
+}
+
+// ── Scoped delete + batch insert ────────────────────────────────
+
+export interface StoreAdapter {
+  sparqlUpdate(query: string): Promise<void>;
+}
+
+export async function deleteExistingSymbols(
+  adapter: StoreAdapter,
+  graphUri: string,
+  modulePaths: string[],
+): Promise<void> {
+  for (const modPath of modulePaths) {
+    const modUri = moduleUri(modPath);
+    await adapter.sparqlUpdate(
+      `DELETE WHERE { GRAPH <${graphUri}> { ?s <${OTX}definedIn> <${modUri}> . ?s ?p ?o } }`
+    );
+  }
+}
+
+export async function pushSymbolTriples(
+  adapter: StoreAdapter,
+  graphUri: string,
+  result: DeepScanResult,
+): Promise<{ triplesInserted: number; batchCount: number }> {
+  // Collect all module paths for scoped delete
+  const modulePaths = new Set<string>();
+  for (const c of result.classes) modulePaths.add(c.filePath);
+  for (const i of result.interfaces) modulePaths.add(i.filePath);
+  for (const f of result.functions) modulePaths.add(f.filePath);
+
+  // Delete existing symbols for these modules
+  await deleteExistingSymbols(adapter, graphUri, [...modulePaths]);
+
+  // Generate and batch-insert
+  const triples = generateSymbolTriples(result);
+  const batches = batchTriples(triples, 100);
+
+  for (const batch of batches) {
+    await adapter.sparqlUpdate(
+      `INSERT DATA { GRAPH <${graphUri}> {\n${batch.join('\n')}\n} }`
+    );
+  }
+
+  return { triplesInserted: triples.length, batchCount: batches.length };
+}

--- a/src/lib/deep-scanner.ts
+++ b/src/lib/deep-scanner.ts
@@ -1,0 +1,375 @@
+/**
+ * Deep scanner — symbol-level codebase analysis using ts-morph.
+ * ts-morph is a peerDependency; when absent the scan gracefully degrades.
+ */
+
+// ── Exported types ──────────────────────────────────────────────
+
+export interface DeepScanOptions {
+  maxFiles?: number;            // default 500
+  maxSymbols?: number;          // default 300
+  timeoutMs?: number;           // default 30_000
+  includeMethodCalls?: boolean; // default false
+}
+
+export interface MethodInfo {
+  name: string;
+  returnType: string;
+  parameters: Array<{ name: string; type: string }>;
+}
+
+export interface ClassInfo {
+  name: string;
+  filePath: string;
+  baseClass: string | null;
+  interfaces: string[];
+  methods: MethodInfo[];
+  isAbstract: boolean;
+}
+
+export interface InterfaceInfo {
+  name: string;
+  filePath: string;
+  extends: string[];
+  methods: Array<{ name: string; returnType: string }>;
+}
+
+export interface FunctionInfo {
+  name: string;
+  filePath: string;
+  returnType: string;
+  parameters: Array<{ name: string; type: string }>;
+  isExported: boolean;
+}
+
+export interface MethodCallInfo {
+  caller: string;  // ClassName.methodName
+  callee: string;  // ClassName.methodName
+}
+
+export interface DeepScanResult {
+  deepScanAvailable: true;
+  classes: ClassInfo[];
+  interfaces: InterfaceInfo[];
+  functions: FunctionInfo[];
+  methodCalls: MethodCallInfo[];
+  fileCount: number;
+  symbolCount: number;
+  scanDurationMs: number;
+  capped: boolean;
+  warnings: string[];
+}
+
+export interface DeepScanUnavailable {
+  deepScanAvailable: false;
+  error: string;
+  fallback: null;
+}
+
+export type DeepScanOutput = DeepScanResult | DeepScanUnavailable;
+
+// ── Dynamic import helper ───────────────────────────────────────
+
+type TsMorph = typeof import('ts-morph');
+
+async function tryImportTsMorph(): Promise<TsMorph | null> {
+  try {
+    return await import('ts-morph');
+  } catch {
+    return null;
+  }
+}
+
+// ── Extractors ──────────────────────────────────────────────────
+
+function qualifiedName(filePath: string, kind: string, name: string): string {
+  return `${filePath}/${kind}/${name}`;
+}
+
+function extractClasses(
+  sourceFile: import('ts-morph').SourceFile,
+  relPath: string,
+): ClassInfo[] {
+  const results: ClassInfo[] = [];
+  for (const cls of sourceFile.getClasses()) {
+    const name = cls.getName();
+    if (!name) continue;
+
+    let baseClass: string | null = null;
+    const baseNode = cls.getBaseClass();
+    if (baseNode) {
+      const baseName = baseNode.getName();
+      if (baseName) {
+        const baseSrc = baseNode.getSourceFile();
+        const baseRel = baseSrc === sourceFile
+          ? relPath
+          : baseSrc.getFilePath().replace(/.*?\/src\//, 'src/').replace(/\.[tj]sx?$/, '');
+        baseClass = qualifiedName(baseRel, 'class', baseName);
+      }
+    }
+
+    const interfaces: string[] = [];
+    for (const impl of cls.getImplements()) {
+      const sym = impl.getExpression().getSymbol();
+      if (sym) {
+        const decls = sym.getDeclarations();
+        if (decls.length > 0) {
+          const decl = decls[0];
+          const declFile = decl.getSourceFile();
+          const declRel = declFile === sourceFile
+            ? relPath
+            : declFile.getFilePath().replace(/.*?\/src\//, 'src/').replace(/\.[tj]sx?$/, '');
+          interfaces.push(qualifiedName(declRel, 'interface', sym.getName()));
+        } else {
+          interfaces.push(sym.getName());
+        }
+      }
+    }
+
+    const methods: MethodInfo[] = [];
+    for (const method of cls.getMethods()) {
+      methods.push({
+        name: method.getName(),
+        returnType: method.getReturnType().getText(method),
+        parameters: method.getParameters().map(p => ({
+          name: p.getName(),
+          type: p.getType().getText(p),
+        })),
+      });
+    }
+
+    results.push({
+      name,
+      filePath: relPath,
+      baseClass,
+      interfaces,
+      methods,
+      isAbstract: cls.isAbstract(),
+    });
+  }
+  return results;
+}
+
+function extractInterfaces(
+  sourceFile: import('ts-morph').SourceFile,
+  relPath: string,
+): InterfaceInfo[] {
+  const results: InterfaceInfo[] = [];
+  for (const iface of sourceFile.getInterfaces()) {
+    const name = iface.getName();
+
+    const extendsArr: string[] = [];
+    for (const ext of iface.getExtends()) {
+      const sym = ext.getExpression().getSymbol();
+      if (sym) extendsArr.push(sym.getName());
+    }
+
+    const methods: Array<{ name: string; returnType: string }> = [];
+    for (const m of iface.getMethods()) {
+      methods.push({
+        name: m.getName(),
+        returnType: m.getReturnType().getText(m),
+      });
+    }
+
+    results.push({ name, filePath: relPath, extends: extendsArr, methods });
+  }
+  return results;
+}
+
+function extractFunctions(
+  sourceFile: import('ts-morph').SourceFile,
+  relPath: string,
+): FunctionInfo[] {
+  const results: FunctionInfo[] = [];
+  for (const fn of sourceFile.getFunctions()) {
+    const name = fn.getName();
+    if (!name) continue;
+    results.push({
+      name,
+      filePath: relPath,
+      returnType: fn.getReturnType().getText(fn),
+      parameters: fn.getParameters().map(p => ({
+        name: p.getName(),
+        type: p.getType().getText(p),
+      })),
+      isExported: fn.isExported(),
+    });
+  }
+  return results;
+}
+
+function extractMethodCalls(
+  sourceFile: import('ts-morph').SourceFile,
+  relPath: string,
+  ts: TsMorph,
+): MethodCallInfo[] {
+  const results: MethodCallInfo[] = [];
+  const SyntaxKind = ts.SyntaxKind;
+
+  for (const cls of sourceFile.getClasses()) {
+    const className = cls.getName();
+    if (!className) continue;
+
+    for (const method of cls.getMethods()) {
+      const callerName = `${className}.${method.getName()}`;
+
+      method.forEachDescendant((node) => {
+        if (node.getKind() === SyntaxKind.CallExpression) {
+          const callExpr = node as import('ts-morph').CallExpression;
+          const expr = callExpr.getExpression();
+          if (expr.getKind() === SyntaxKind.PropertyAccessExpression) {
+            const propAccess = expr as import('ts-morph').PropertyAccessExpression;
+            const sym = propAccess.getSymbol();
+            if (sym) {
+              const decls = sym.getDeclarations();
+              if (decls.length > 0) {
+                const decl = decls[0];
+                const parent = decl.getParent();
+                if (parent && 'getName' in parent && typeof parent.getName === 'function') {
+                  const parentName = parent.getName() as string;
+                  if (parentName) {
+                    results.push({
+                      caller: callerName,
+                      callee: `${parentName}.${sym.getName()}`,
+                    });
+                  }
+                }
+              }
+            }
+          }
+        }
+      });
+    }
+  }
+  return results;
+}
+
+// ── Main entry point ────────────────────────────────────────────
+
+export async function deepScan(
+  rootDir: string,
+  options?: DeepScanOptions,
+): Promise<DeepScanOutput> {
+  const ts = await tryImportTsMorph();
+  if (!ts) {
+    return {
+      deepScanAvailable: false,
+      error: 'ts-morph not installed. Run: npm install ts-morph',
+      fallback: null,
+    };
+  }
+
+  const maxFiles = options?.maxFiles ?? 500;
+  const maxSymbols = options?.maxSymbols ?? 300;
+  const timeoutMs = options?.timeoutMs ?? 30_000;
+  const includeMethodCalls = options?.includeMethodCalls ?? false;
+
+  const start = Date.now();
+  const warnings: string[] = [];
+
+  // Initialise ts-morph Project
+  const { Project } = ts;
+  let project: InstanceType<typeof Project>;
+  try {
+    project = new Project({
+      tsConfigFilePath: `${rootDir}/tsconfig.json`,
+      skipAddingFilesFromTsConfig: false,
+      skipFileDependencyResolution: true,
+    });
+  } catch {
+    return {
+      deepScanAvailable: false,
+      error: `Failed to load tsconfig.json from ${rootDir}`,
+      fallback: null,
+    };
+  }
+
+  const sourceFiles = project.getSourceFiles()
+    .filter(sf => !sf.getFilePath().includes('node_modules'))
+    .filter(sf => !sf.getFilePath().includes('/dist/'));
+
+  if (sourceFiles.length > maxFiles) {
+    return {
+      deepScanAvailable: true,
+      classes: [],
+      interfaces: [],
+      functions: [],
+      methodCalls: [],
+      fileCount: sourceFiles.length,
+      symbolCount: 0,
+      scanDurationMs: Date.now() - start,
+      capped: true,
+      warnings: [`File count ${sourceFiles.length} exceeds maxFiles ${maxFiles}. Scan skipped.`],
+    };
+  }
+
+  const classes: ClassInfo[] = [];
+  const interfaces: InterfaceInfo[] = [];
+  const functions: FunctionInfo[] = [];
+  const methodCalls: MethodCallInfo[] = [];
+  let symbolCount = 0;
+  let capped = false;
+
+  for (const sf of sourceFiles) {
+    if (Date.now() - start > timeoutMs) {
+      capped = true;
+      warnings.push(`Timeout after ${timeoutMs}ms. Returning partial results.`);
+      break;
+    }
+
+    const fullPath = sf.getFilePath();
+    const relPath = fullPath
+      .replace(rootDir.endsWith('/') ? rootDir : rootDir + '/', '')
+      .replace(/\.[tj]sx?$/, '');
+
+    try {
+      const cls = extractClasses(sf, relPath);
+      for (const c of cls) {
+        if (symbolCount >= maxSymbols) { capped = true; break; }
+        classes.push(c);
+        symbolCount++;
+        // Count methods as symbols too
+        symbolCount += c.methods.length;
+      }
+      if (capped) break;
+
+      const ifaces = extractInterfaces(sf, relPath);
+      for (const i of ifaces) {
+        if (symbolCount >= maxSymbols) { capped = true; break; }
+        interfaces.push(i);
+        symbolCount++;
+      }
+      if (capped) break;
+
+      const fns = extractFunctions(sf, relPath);
+      for (const f of fns) {
+        if (symbolCount >= maxSymbols) { capped = true; break; }
+        functions.push(f);
+        symbolCount++;
+      }
+      if (capped) break;
+
+      if (includeMethodCalls) {
+        const calls = extractMethodCalls(sf, relPath, ts);
+        methodCalls.push(...calls);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      warnings.push(`Skipped ${relPath}: ${msg}`);
+    }
+  }
+
+  return {
+    deepScanAvailable: true,
+    classes,
+    interfaces,
+    functions,
+    methodCalls,
+    fileCount: sourceFiles.length,
+    symbolCount,
+    scanDurationMs: Date.now() - start,
+    capped,
+    warnings,
+  };
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -9,6 +9,8 @@ import {
   GetPromptRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { loadConfig, saveConfig, configExists, resolveGraphUri } from '../lib/config.js';
+import { deepScan } from '../lib/deep-scanner.js';
+import { pushSymbolTriples } from '../lib/deep-scan-triples.js';
 import type { OpenTologyConfig } from '../lib/config.js';
 import { createReadyAdapter } from '../lib/store-factory.js';
 import type { StoreAdapter } from '../lib/store-adapter.js';
@@ -377,6 +379,42 @@ async function handleInfer(args: Record<string, unknown>): Promise<unknown> {
 }
 
 async function handleContextScan(args: Record<string, unknown>): Promise<unknown> {
+  const depth = (args.depth as string | undefined) ?? 'module';
+
+  if (depth === 'symbol') {
+    const scanResult = await deepScan(process.cwd(), {
+      maxFiles: args.maxFiles as number | undefined,
+      maxSymbols: args.maxSymbols as number | undefined,
+      timeoutMs: args.timeoutMs as number | undefined,
+      includeMethodCalls: args.includeMethodCalls as boolean | undefined,
+    });
+
+    if (!scanResult.deepScanAvailable) {
+      return scanResult;
+    }
+
+    // Auto-push triples server-side
+    let pushStats: { triplesInserted: number; batchCount: number } | null = null;
+    try {
+      const config = loadConfig();
+      const contextUri = `${config.graphUri}/context`;
+      const adapter = await createReadyAdapter(config);
+      pushStats = await pushSymbolTriples(adapter, contextUri, scanResult);
+    } catch {
+      // Non-fatal: push is best-effort
+    }
+
+    return {
+      ...scanResult,
+      pushStats,
+      _experimental: true,
+      _hint: pushStats
+        ? `Symbol triples pushed: ${pushStats.triplesInserted} triples in ${pushStats.batchCount} batches. Query with: SELECT ?c WHERE { ?c a otx:Class ; otx:definedIn <urn:module:...> }`
+        : 'Deep scan completed but triple push failed. Use opentology_push manually with the generated triples.',
+    };
+  }
+
+  // Default: module-level scan (existing behavior)
   const maxBytes = (args.maxSnapshotBytes as number | undefined) ?? 15360;
   const snapshot = await scanCodebase(process.cwd(), maxBytes);
   return {
@@ -1026,13 +1064,34 @@ export async function startMcpServer(): Promise<void> {
       },
       {
         name: 'opentology_context_scan',
-        description: 'Scan the current project codebase and return a structured snapshot (package.json, directory tree, entry points, detected frameworks, dependency graph). Includes module dependency edges extracted from import statements. Use the snapshot to create Knowledge and Module triples via opentology_push. Can be called independently of context_init.',
+        description: 'Scan the current project codebase. depth="module" (default) returns a structured snapshot with file-level dependency graph. depth="symbol" (experimental) uses ts-morph to extract class/interface/method-level dependencies and auto-pushes OTX triples to the context graph.',
         inputSchema: {
           type: 'object' as const,
           properties: {
             maxSnapshotBytes: {
               type: 'number',
-              description: 'Maximum snapshot payload size in bytes (default: 15360). Truncates and warns if exceeded.',
+              description: 'Maximum snapshot payload size in bytes (default: 15360). Only used when depth="module".',
+            },
+            depth: {
+              type: 'string',
+              enum: ['module', 'symbol'],
+              description: 'Scan depth: "module" for file-level imports (default), "symbol" for class/interface/method-level analysis (experimental, requires ts-morph).',
+            },
+            maxSymbols: {
+              type: 'number',
+              description: 'Maximum symbols to extract when depth="symbol" (default: 300).',
+            },
+            maxFiles: {
+              type: 'number',
+              description: 'Maximum source files to scan when depth="symbol" (default: 500).',
+            },
+            timeoutMs: {
+              type: 'number',
+              description: 'Timeout in milliseconds for symbol scan (default: 30000).',
+            },
+            includeMethodCalls: {
+              type: 'boolean',
+              description: 'Extract method call relationships when depth="symbol" (default: false, expensive).',
             },
           },
         },

--- a/src/templates/otx-ontology.ts
+++ b/src/templates/otx-ontology.ts
@@ -25,6 +25,19 @@ otx:project a owl:ObjectProperty .
 otx:dependsOn a owl:ObjectProperty ; rdfs:domain otx:Module ; rdfs:range otx:Module .
 otx:stack a owl:DatatypeProperty ; rdfs:range xsd:string .
 otx:alternative a owl:DatatypeProperty ; rdfs:range xsd:string .
+
+otx:Class a owl:Class .
+otx:Interface a owl:Class .
+otx:Function a owl:Class .
+otx:Method a owl:Class .
+
+otx:definedIn a owl:ObjectProperty ; rdfs:range otx:Module .
+otx:extends a owl:ObjectProperty ; rdfs:domain otx:Class ; rdfs:range otx:Class .
+otx:implements a owl:ObjectProperty ; rdfs:domain otx:Class ; rdfs:range otx:Interface .
+otx:hasMethod a owl:ObjectProperty ; rdfs:domain otx:Class ; rdfs:range otx:Method .
+otx:calls a owl:ObjectProperty ; rdfs:domain otx:Method ; rdfs:range otx:Method .
+otx:returns a owl:DatatypeProperty ; rdfs:range xsd:string .
+otx:paramType a owl:DatatypeProperty ; rdfs:range xsd:string .
 `;
 
 export function buildAskQuery(contextGraphUri: string): string {

--- a/tests/unit/deep-scan-triples.test.ts
+++ b/tests/unit/deep-scan-triples.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect } from 'vitest';
+import { Parser } from 'n3';
+import {
+  generateSymbolTriples,
+  batchTriples,
+} from '../../src/lib/deep-scan-triples.js';
+import type { DeepScanResult } from '../../src/lib/deep-scanner.js';
+
+function makeResult(overrides?: Partial<DeepScanResult>): DeepScanResult {
+  return {
+    deepScanAvailable: true,
+    classes: [],
+    interfaces: [],
+    functions: [],
+    methodCalls: [],
+    fileCount: 1,
+    symbolCount: 0,
+    scanDurationMs: 100,
+    capped: false,
+    warnings: [],
+    ...overrides,
+  };
+}
+
+describe('generateSymbolTriples', () => {
+  it('generates valid Turtle that parses via N3', () => {
+    const result = makeResult({
+      classes: [{
+        name: 'Foo',
+        filePath: 'src/lib/foo',
+        baseClass: null,
+        interfaces: [],
+        methods: [{ name: 'bar', returnType: 'string', parameters: [] }],
+        isAbstract: false,
+      }],
+    });
+
+    const triples = generateSymbolTriples(result);
+    expect(triples.length).toBeGreaterThan(0);
+
+    // Parse as Turtle — N3 parser needs a base and prefix-free NTriples-like format
+    const parser = new Parser({ format: 'N-Triples' });
+    const quads = parser.parse(triples.join('\n'));
+    expect(quads.length).toBeGreaterThan(0);
+  });
+
+  it('produces otx:Class triple for classes', () => {
+    const result = makeResult({
+      classes: [{
+        name: 'MyClass',
+        filePath: 'src/app',
+        baseClass: null,
+        interfaces: [],
+        methods: [],
+        isAbstract: false,
+      }],
+    });
+
+    const triples = generateSymbolTriples(result);
+    const classTriple = triples.find(t => t.includes('vocab#Class'));
+    expect(classTriple).toBeDefined();
+    expect(classTriple).toContain('urn:symbol:');
+  });
+
+  it('produces otx:extends triple for inheritance', () => {
+    const result = makeResult({
+      classes: [{
+        name: 'Child',
+        filePath: 'src/child',
+        baseClass: 'src/parent/class/Parent',
+        interfaces: [],
+        methods: [],
+        isAbstract: false,
+      }],
+    });
+
+    const triples = generateSymbolTriples(result);
+    const extendsTriple = triples.find(t => t.includes('vocab#extends'));
+    expect(extendsTriple).toBeDefined();
+    expect(extendsTriple).toContain('Parent');
+  });
+
+  it('produces otx:implements triple for interface implementation', () => {
+    const result = makeResult({
+      classes: [{
+        name: 'Impl',
+        filePath: 'src/impl',
+        baseClass: null,
+        interfaces: ['src/types/interface/Serializable'],
+        methods: [],
+        isAbstract: false,
+      }],
+    });
+
+    const triples = generateSymbolTriples(result);
+    const implTriple = triples.find(t => t.includes('vocab#implements'));
+    expect(implTriple).toBeDefined();
+    expect(implTriple).toContain('Serializable');
+  });
+
+  it('produces otx:definedIn for every symbol', () => {
+    const result = makeResult({
+      classes: [{
+        name: 'A',
+        filePath: 'src/a',
+        baseClass: null,
+        interfaces: [],
+        methods: [],
+        isAbstract: false,
+      }],
+      interfaces: [{
+        name: 'B',
+        filePath: 'src/b',
+        extends: [],
+        methods: [],
+      }],
+      functions: [{
+        name: 'c',
+        filePath: 'src/c',
+        returnType: 'void',
+        parameters: [],
+        isExported: true,
+      }],
+    });
+
+    const triples = generateSymbolTriples(result);
+    const definedInTriples = triples.filter(t => t.includes('vocab#definedIn'));
+    // class A, interface B, function c → at least 3 definedIn triples
+    expect(definedInTriples.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('produces no rdfs:subClassOf triples', () => {
+    const result = makeResult({
+      classes: [{
+        name: 'X',
+        filePath: 'src/x',
+        baseClass: null,
+        interfaces: [],
+        methods: [{ name: 'm', returnType: 'void', parameters: [] }],
+        isAbstract: false,
+      }],
+    });
+
+    const triples = generateSymbolTriples(result);
+    const subClassTriples = triples.filter(t => t.includes('subClassOf'));
+    expect(subClassTriples.length).toBe(0);
+  });
+
+  it('produces otx:Interface triple for interfaces', () => {
+    const result = makeResult({
+      interfaces: [{
+        name: 'MyInterface',
+        filePath: 'src/types',
+        extends: [],
+        methods: [{ name: 'doSomething', returnType: 'void' }],
+      }],
+    });
+
+    const triples = generateSymbolTriples(result);
+    const ifaceTriple = triples.find(t => t.includes('vocab#Interface'));
+    expect(ifaceTriple).toBeDefined();
+  });
+
+  it('produces otx:Function triple for functions', () => {
+    const result = makeResult({
+      functions: [{
+        name: 'helper',
+        filePath: 'src/utils',
+        returnType: 'string',
+        parameters: [{ name: 'x', type: 'number' }],
+        isExported: true,
+      }],
+    });
+
+    const triples = generateSymbolTriples(result);
+    const fnTriple = triples.find(t => t.includes('vocab#Function'));
+    expect(fnTriple).toBeDefined();
+    const returnsTriple = triples.find(t => t.includes('vocab#returns'));
+    expect(returnsTriple).toBeDefined();
+  });
+});
+
+describe('batchTriples', () => {
+  it('splits 350 triples into 4 batches of max 100', () => {
+    const triples = Array.from({ length: 350 }, (_, i) => `<urn:s:${i}> <urn:p> <urn:o> .`);
+    const batches = batchTriples(triples, 100);
+    expect(batches.length).toBe(4);
+    expect(batches[0].length).toBe(100);
+    expect(batches[1].length).toBe(100);
+    expect(batches[2].length).toBe(100);
+    expect(batches[3].length).toBe(50);
+  });
+
+  it('returns single batch for small input', () => {
+    const triples = ['<urn:a> <urn:b> <urn:c> .'];
+    const batches = batchTriples(triples, 100);
+    expect(batches.length).toBe(1);
+    expect(batches[0].length).toBe(1);
+  });
+
+  it('returns empty array for empty input', () => {
+    const batches = batchTriples([], 100);
+    expect(batches.length).toBe(0);
+  });
+});

--- a/tests/unit/deep-scanner.test.ts
+++ b/tests/unit/deep-scanner.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, writeFile, mkdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { deepScan } from '../../src/lib/deep-scanner.js';
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'deep-scan-'));
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+async function writeTsConfig(dir: string) {
+  await writeFile(join(dir, 'tsconfig.json'), JSON.stringify({
+    compilerOptions: {
+      target: 'ES2020',
+      module: 'ESNext',
+      moduleResolution: 'bundler',
+      strict: true,
+      skipLibCheck: true,
+      outDir: './dist',
+    },
+    include: ['src/**/*.ts'],
+  }));
+}
+
+async function writeSourceFile(dir: string, relPath: string, content: string) {
+  const fullPath = join(dir, relPath);
+  const parent = fullPath.substring(0, fullPath.lastIndexOf('/'));
+  await mkdir(parent, { recursive: true });
+  await writeFile(fullPath, content);
+}
+
+describe('deep-scanner', () => {
+  describe('class extraction', () => {
+    it('extracts a single class with methods', async () => {
+      await writeTsConfig(tempDir);
+      await writeSourceFile(tempDir, 'src/service.ts', `
+        export class UserService {
+          getName(): string { return 'test'; }
+          getAge(id: number): number { return 0; }
+        }
+      `);
+
+      const result = await deepScan(tempDir);
+      expect(result.deepScanAvailable).toBe(true);
+      if (!result.deepScanAvailable) return;
+
+      expect(result.classes.length).toBe(1);
+      const cls = result.classes[0];
+      expect(cls.name).toBe('UserService');
+      expect(cls.methods.length).toBe(2);
+      expect(cls.methods[0].name).toBe('getName');
+      expect(cls.methods[1].name).toBe('getAge');
+      expect(cls.methods[1].parameters.length).toBe(1);
+      expect(cls.methods[1].parameters[0].name).toBe('id');
+    });
+
+    it('detects abstract classes', async () => {
+      await writeTsConfig(tempDir);
+      await writeSourceFile(tempDir, 'src/base.ts', `
+        export abstract class BaseHandler {
+          abstract handle(): void;
+        }
+      `);
+
+      const result = await deepScan(tempDir);
+      if (!result.deepScanAvailable) return;
+
+      expect(result.classes[0].isAbstract).toBe(true);
+    });
+  });
+
+  describe('inheritance', () => {
+    it('resolves cross-file inheritance', async () => {
+      await writeTsConfig(tempDir);
+      await writeSourceFile(tempDir, 'src/base.ts', `
+        export class Animal {
+          move(): void {}
+        }
+      `);
+      await writeSourceFile(tempDir, 'src/dog.ts', `
+        import { Animal } from './base.js';
+        export class Dog extends Animal {
+          bark(): void {}
+        }
+      `);
+
+      const result = await deepScan(tempDir);
+      if (!result.deepScanAvailable) return;
+
+      const dog = result.classes.find(c => c.name === 'Dog');
+      expect(dog).toBeDefined();
+      expect(dog!.baseClass).toContain('Animal');
+      expect(dog!.baseClass).toContain('class');
+    });
+
+    it('resolves same-file inheritance', async () => {
+      await writeTsConfig(tempDir);
+      await writeSourceFile(tempDir, 'src/shapes.ts', `
+        export class Shape {
+          area(): number { return 0; }
+        }
+        export class Circle extends Shape {
+          radius = 1;
+        }
+      `);
+
+      const result = await deepScan(tempDir);
+      if (!result.deepScanAvailable) return;
+
+      const circle = result.classes.find(c => c.name === 'Circle');
+      expect(circle).toBeDefined();
+      expect(circle!.baseClass).toContain('Shape');
+    });
+  });
+
+  describe('interface implementation', () => {
+    it('detects class implementing interface', async () => {
+      await writeTsConfig(tempDir);
+      await writeSourceFile(tempDir, 'src/types.ts', `
+        export interface Serializable {
+          serialize(): string;
+        }
+      `);
+      await writeSourceFile(tempDir, 'src/model.ts', `
+        import { Serializable } from './types.js';
+        export class User implements Serializable {
+          serialize(): string { return '{}'; }
+        }
+      `);
+
+      const result = await deepScan(tempDir);
+      if (!result.deepScanAvailable) return;
+
+      const user = result.classes.find(c => c.name === 'User');
+      expect(user).toBeDefined();
+      expect(user!.interfaces.length).toBe(1);
+      expect(user!.interfaces[0]).toContain('Serializable');
+    });
+  });
+
+  describe('interface extraction', () => {
+    it('extracts interfaces with extends', async () => {
+      await writeTsConfig(tempDir);
+      await writeSourceFile(tempDir, 'src/types.ts', `
+        export interface Base {
+          id(): string;
+        }
+        export interface Extended extends Base {
+          name(): string;
+        }
+      `);
+
+      const result = await deepScan(tempDir);
+      if (!result.deepScanAvailable) return;
+
+      const ext = result.interfaces.find(i => i.name === 'Extended');
+      expect(ext).toBeDefined();
+      expect(ext!.extends).toContain('Base');
+      expect(ext!.methods.length).toBe(1);
+    });
+  });
+
+  describe('function extraction', () => {
+    it('extracts top-level functions', async () => {
+      await writeTsConfig(tempDir);
+      await writeSourceFile(tempDir, 'src/utils.ts', `
+        export function greet(name: string): string {
+          return 'hello ' + name;
+        }
+        function internal(): void {}
+      `);
+
+      const result = await deepScan(tempDir);
+      if (!result.deepScanAvailable) return;
+
+      expect(result.functions.length).toBe(2);
+      const greet = result.functions.find(f => f.name === 'greet');
+      expect(greet).toBeDefined();
+      expect(greet!.isExported).toBe(true);
+      expect(greet!.parameters[0].name).toBe('name');
+    });
+  });
+
+  describe('maxSymbols cap', () => {
+    it('caps symbols and sets capped flag', async () => {
+      await writeTsConfig(tempDir);
+      // Create 20 classes
+      let content = '';
+      for (let i = 0; i < 20; i++) {
+        content += `export class C${i} { m${i}(): void {} }\n`;
+      }
+      await writeSourceFile(tempDir, 'src/many.ts', content);
+
+      const result = await deepScan(tempDir, { maxSymbols: 5 });
+      if (!result.deepScanAvailable) return;
+
+      expect(result.capped).toBe(true);
+      // symbolCount includes classes + their methods
+      expect(result.symbolCount).toBeLessThanOrEqual(10); // 5 classes + up to 5 methods
+    });
+  });
+
+  describe('error handling', () => {
+    it('skips files with syntax errors and adds warning', async () => {
+      await writeTsConfig(tempDir);
+      await writeSourceFile(tempDir, 'src/good.ts', `
+        export class Good { run(): void {} }
+      `);
+      await writeSourceFile(tempDir, 'src/bad.ts', `
+        export class Bad {{{{{ syntax error
+      `);
+
+      const result = await deepScan(tempDir);
+      if (!result.deepScanAvailable) return;
+
+      // Should have at least the good class
+      expect(result.classes.some(c => c.name === 'Good')).toBe(true);
+      // Bad file may produce a warning or ts-morph may handle parse errors gracefully
+    });
+
+    it('returns unavailable when tsconfig is missing', async () => {
+      // No tsconfig.json written
+      await writeSourceFile(tempDir, 'src/foo.ts', 'export class Foo {}');
+
+      const result = await deepScan(tempDir);
+      expect(result.deepScanAvailable).toBe(false);
+    });
+  });
+
+  describe('URI scheme', () => {
+    it('uses urn:symbol path/kind/name format in result data', async () => {
+      await writeTsConfig(tempDir);
+      await writeSourceFile(tempDir, 'src/app.ts', `
+        export class App { start(): void {} }
+      `);
+
+      const result = await deepScan(tempDir);
+      if (!result.deepScanAvailable) return;
+
+      const cls = result.classes[0];
+      expect(cls.filePath).toBe('src/app');
+      expect(cls.name).toBe('App');
+      // The URI is constructed in deep-scan-triples.ts, but filePath + name are the building blocks
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Extend `opentology_context_scan` with `depth: "symbol"` mode using ts-morph (optional peerDependency)
- Extract class/interface/method-level dependencies and auto-push OTX triples
- Add 4 OTX classes (`otx:Class`, `otx:Interface`, `otx:Function`, `otx:Method`) + 7 properties
- Batched triple insert (100/batch) with scoped delete-then-insert per module

## Changes
| File | Action |
|------|--------|
| `src/templates/otx-ontology.ts` | +4 classes, +7 properties |
| `src/lib/deep-scanner.ts` | **New** — ts-morph symbol extractor |
| `src/lib/deep-scan-triples.ts` | **New** — triple generator with batch insert |
| `src/mcp/server.ts` | `depth` param + handler |
| `package.json` | ts-morph as optional peerDep |
| `tests/unit/deep-scanner.test.ts` | **New** — 12 test cases |
| `tests/unit/deep-scan-triples.test.ts` | **New** — 10 test cases |

## Test plan
- [x] `npm run build` passes
- [x] 97 tests pass (75 existing + 22 new)
- [x] Architect review: APPROVED
- [ ] Manual: `opentology_context_scan` with default params unchanged
- [ ] Manual: `depth: "symbol"` extracts classes from OpenTology itself

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)