### PR TITLE
feat: multi-language deep-scan via Tree-sitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ graph TB
     end
 
     subgraph MCP["MCP Server"]
-        Tools[11 Tools]
+        Tools[18 Tools]
         Resource["opentology://schema"]
     end
 
@@ -97,7 +97,7 @@ graph LR
 | Docker required | No (embedded mode) | Yes | Yes |
 | RDFS reasoning | Automatic on push | Manual SPARQL CONSTRUCT | Not native |
 | SHACL validation | Built-in | Manual tooling | N/A |
-| AI integration | MCP server with 11 tools | None | Plugin ecosystem |
+| AI integration | MCP server with 18 tools | None | Plugin ecosystem |
 | Query language | SPARQL (auto-prefixed) | SPARQL (raw) | Cypher |
 | Data format | Turtle files | Turtle/N-Triples | Property graph |
 | Project scoping | Automatic named graphs | Manual | Database-level |
@@ -126,7 +126,7 @@ graph LR
 
 **AI Integration**
 
-- MCP server with 11 tools and 1 resource
+- MCP server with 18 tools and 1 resource
 - `opentology://schema` resource auto-loads ontology overview
 - Works with Claude Code, Cursor, and any MCP-compatible client
 
@@ -192,7 +192,7 @@ Add to your MCP client configuration (`.mcp.json`):
 }
 ```
 
-**11 Tools:**
+**18 Tools:**
 
 | Tool | Description |
 |------|-------------|
@@ -207,6 +207,13 @@ Add to your MCP client configuration (`.mcp.json`):
 | `opentology_diff` | Compare local vs graph |
 | `opentology_schema` | Introspect ontology schema |
 | `opentology_infer` | Run RDFS inference |
+| `opentology_graph_list` | List named graphs |
+| `opentology_graph_create` | Create a named graph |
+| `opentology_graph_drop` | Drop a named graph |
+| `opentology_context_init` | Initialize project context graph |
+| `opentology_context_load` | Load project context |
+| `opentology_context_status` | Check context initialization status |
+| `opentology_context_scan` | Scan codebase (module or symbol-level) |
 
 **1 Resource:**
 
@@ -270,6 +277,41 @@ opentology push data.ttl
 opentology shapes
 ```
 
+### Deep Scan (Symbol-Level Analysis)
+
+The `opentology_context_scan` MCP tool supports symbol-level deep scanning that extracts classes, interfaces, functions, and method call relationships from source code, then pushes them as OTX triples to the context graph.
+
+**Supported Languages:**
+
+| Language | Engine | Symbols Extracted |
+|----------|--------|-------------------|
+| TypeScript/JavaScript | ts-morph | class, interface, function, method calls |
+| Python | Tree-sitter | class, ABC/Protocol, function, method calls |
+| Go | Tree-sitter | struct, interface, func, method calls |
+| Rust | Tree-sitter | struct, trait, impl, fn, method calls |
+| Java | Tree-sitter | class, interface, method, method calls |
+| Swift | Tree-sitter | class, struct, protocol, func, method calls |
+
+**Optional Dependencies:**
+
+```bash
+# For TypeScript/JavaScript deep scan
+npm install ts-morph
+
+# For Python/Go/Rust/Java/Swift deep scan
+npm install web-tree-sitter tree-sitter-wasms
+```
+
+**Usage (MCP):**
+
+```json
+{
+  "depth": "symbol",
+  "includeMethodCalls": true,
+  "languages": ["typescript", "python"]
+}
+```
+
 ### Tech Stack
 
 - TypeScript, commander.js, n3.js
@@ -277,11 +319,13 @@ opentology shapes
 - @modelcontextprotocol/sdk for MCP server
 - shacl-engine for SHACL validation
 - picocolors for terminal output
+- ts-morph (optional) for TypeScript symbol analysis
+- web-tree-sitter + tree-sitter-wasms (optional) for multi-language symbol analysis
 
 ### Roadmap
 
 - [x] CLI with 14 commands
-- [x] MCP server with 11 tools and 1 resource
+- [x] MCP server with 18 tools and 1 resource
 - [x] Schema introspection (MCP resource + tool)
 - [x] Complete CRUD (push --replace, drop, delete)
 - [x] SHACL validation (shape constraints on push)
@@ -290,6 +334,7 @@ opentology shapes
 - [x] Prefix management
 - [x] Embedded mode (no Docker required)
 - [x] RDFS reasoning (auto-materialization on push)
+- [x] Multi-language deep scan (TypeScript, Python, Go, Rust, Java, Swift)
 - [ ] OWL reasoning (owl:sameAs, owl:inverseOf)
 - [ ] Remote ontology import
 - [ ] Version control for ontology snapshots
@@ -324,7 +369,7 @@ graph TB
     end
 
     subgraph MCP["MCP Server"]
-        Tools[11 Tools]
+        Tools[18 Tools]
         Resource["opentology://schema"]
     end
 
@@ -399,7 +444,7 @@ graph LR
 | Docker 필수 | 아니오 (임베디드 모드) | 예 | 예 |
 | RDFS 추론 | 푸시 시 자동 | SPARQL CONSTRUCT 수동 작성 | 네이티브 미지원 |
 | SHACL 검증 | 내장 | 별도 도구 필요 | 해당 없음 |
-| AI 연동 | MCP 서버 11개 도구 | 없음 | 플러그인 생태계 |
+| AI 연동 | MCP 서버 18개 도구 | 없음 | 플러그인 생태계 |
 | 쿼리 언어 | SPARQL (접두사 자동 삽입) | SPARQL (수동) | Cypher |
 | 데이터 형식 | Turtle 파일 | Turtle/N-Triples | 속성 그래프 |
 | 프로젝트 구분 | Named Graph 자동 | 수동 관리 | 데이터베이스 단위 |
@@ -428,7 +473,7 @@ graph LR
 
 **AI 연동**
 
-- 11개 도구와 1개 리소스를 제공하는 MCP 서버
+- 18개 도구와 1개 리소스를 제공하는 MCP 서버
 - `opentology://schema` 리소스로 온톨로지 개요 자동 로드
 - Claude Code, Cursor 등 MCP 호환 클라이언트와 연동
 
@@ -494,7 +539,7 @@ MCP 클라이언트 설정 파일(`.mcp.json`)에 추가:
 }
 ```
 
-**11개 도구:**
+**18개 도구:**
 
 | 도구 | 설명 |
 |------|------|
@@ -509,6 +554,13 @@ MCP 클라이언트 설정 파일(`.mcp.json`)에 추가:
 | `opentology_diff` | 로컬 파일과 그래프 비교 |
 | `opentology_schema` | 온톨로지 스키마 조회 |
 | `opentology_infer` | RDFS 추론 실행 |
+| `opentology_graph_list` | Named Graph 목록 조회 |
+| `opentology_graph_create` | Named Graph 생성 |
+| `opentology_graph_drop` | Named Graph 삭제 |
+| `opentology_context_init` | 프로젝트 컨텍스트 그래프 초기화 |
+| `opentology_context_load` | 프로젝트 컨텍스트 로드 |
+| `opentology_context_status` | 컨텍스트 초기화 상태 확인 |
+| `opentology_context_scan` | 코드베이스 스캔 (모듈/심볼 수준) |
 
 **1개 리소스:**
 
@@ -572,6 +624,41 @@ opentology push data.ttl
 opentology shapes
 ```
 
+### 딥스캔 (심볼 수준 분석)
+
+`opentology_context_scan` MCP 도구는 소스 코드에서 클래스, 인터페이스, 함수, 메서드 호출 관계를 추출하여 OTX 트리플로 컨텍스트 그래프에 푸시하는 심볼 수준 딥스캔을 지원합니다.
+
+**지원 언어:**
+
+| 언어 | 엔진 | 추출 심볼 |
+|------|------|-----------|
+| TypeScript/JavaScript | ts-morph | class, interface, function, method calls |
+| Python | Tree-sitter | class, ABC/Protocol, function, method calls |
+| Go | Tree-sitter | struct, interface, func, method calls |
+| Rust | Tree-sitter | struct, trait, impl, fn, method calls |
+| Java | Tree-sitter | class, interface, method, method calls |
+| Swift | Tree-sitter | class, struct, protocol, func, method calls |
+
+**선택적 의존성:**
+
+```bash
+# TypeScript/JavaScript 딥스캔
+npm install ts-morph
+
+# Python/Go/Rust/Java/Swift 딥스캔
+npm install web-tree-sitter tree-sitter-wasms
+```
+
+**사용법 (MCP):**
+
+```json
+{
+  "depth": "symbol",
+  "includeMethodCalls": true,
+  "languages": ["typescript", "python"]
+}
+```
+
 ### 기술 스택
 
 - TypeScript, commander.js, n3.js
@@ -579,11 +666,13 @@ opentology shapes
 - @modelcontextprotocol/sdk (MCP 서버)
 - shacl-engine (SHACL 검증)
 - picocolors (터미널 출력)
+- ts-morph (선택) TypeScript 심볼 분석
+- web-tree-sitter + tree-sitter-wasms (선택) 다중 언어 심볼 분석
 
 ### 로드맵
 
 - [x] 14개 CLI 명령어
-- [x] 11개 도구와 1개 리소스를 갖춘 MCP 서버
+- [x] 18개 도구와 1개 리소스를 갖춘 MCP 서버
 - [x] 스키마 조회 (MCP 리소스 + 도구)
 - [x] 완전한 CRUD (push --replace, drop, delete)
 - [x] SHACL 검증 (푸시 시 형상 제약 자동 검증)
@@ -592,6 +681,7 @@ opentology shapes
 - [x] 접두사 관리
 - [x] 임베디드 모드 (Docker 불필요)
 - [x] RDFS 추론 (푸시 시 자동 물질화)
+- [x] 다중 언어 딥스캔 (TypeScript, Python, Go, Rust, Java, Swift)
 - [ ] OWL 추론 (owl:sameAs, owl:inverseOf)
 - [ ] 원격 온톨로지 임포트
 - [ ] 온톨로지 스냅샷 버전 관리

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,19 +23,29 @@
       "devDependencies": {
         "@types/n3": "^1.26.1",
         "@types/node": "^25.5.0",
+        "tree-sitter-wasms": "^0.1.13",
         "ts-morph": "^27.0.2",
         "ts-node": "^10.9.2",
         "typescript": "^6.0.2",
-        "vitest": "^4.1.2"
+        "vitest": "^4.1.2",
+        "web-tree-sitter": "^0.26.8"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "ts-morph": ">=21.0.0"
+        "tree-sitter-wasms": ">=0.1.0",
+        "ts-morph": ">=21.0.0",
+        "web-tree-sitter": ">=0.24.0"
       },
       "peerDependenciesMeta": {
+        "tree-sitter-wasms": {
+          "optional": true
+        },
         "ts-morph": {
+          "optional": true
+        },
+        "web-tree-sitter": {
           "optional": true
         }
       }
@@ -8482,6 +8492,16 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/tree-sitter-wasms": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/tree-sitter-wasms/-/tree-sitter-wasms-0.1.13.tgz",
+      "integrity": "sha512-wT+cR6DwaIz80/vho3AvSF0N4txuNx/5bcRKoXouOfClpxh/qqrF4URNLQXbbt8MaAxeksZcZd1j8gcGjc+QxQ==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "tree-sitter-wasms": "^0.1.11"
+      }
+    },
     "node_modules/triple-beam": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
@@ -8815,6 +8835,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/web-tree-sitter": {
+      "version": "0.26.8",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.26.8.tgz",
+      "integrity": "sha512-4sUwi7ZyOrIk5KLgYLkc2A/F0LFMQnBhfb+2Cdl7ik4ePJ6JD+fk4ofI2sA5eGawBKBaK4Vntt7Ww5KcEsay4A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -49,18 +49,28 @@
     "shacl-engine": "^1.1.0"
   },
   "peerDependencies": {
-    "ts-morph": ">=21.0.0"
+    "ts-morph": ">=21.0.0",
+    "web-tree-sitter": ">=0.24.0",
+    "tree-sitter-wasms": ">=0.1.0"
   },
   "peerDependenciesMeta": {
     "ts-morph": {
+      "optional": true
+    },
+    "web-tree-sitter": {
+      "optional": true
+    },
+    "tree-sitter-wasms": {
       "optional": true
     }
   },
   "devDependencies": {
     "@types/n3": "^1.26.1",
     "@types/node": "^25.5.0",
+    "tree-sitter-wasms": "^0.1.13",
     "ts-morph": "^27.0.2",
     "ts-node": "^10.9.2",
+    "web-tree-sitter": "^0.26.8",
     "typescript": "^6.0.2",
     "vitest": "^4.1.2"
   }

--- a/src/lib/deep-scanner-treesitter.ts
+++ b/src/lib/deep-scanner-treesitter.ts
@@ -1,0 +1,215 @@
+/**
+ * Tree-sitter base extractor — abstract class that handles WASM loading,
+ * parser initialization, and provides query helpers for language-specific extractors.
+ *
+ * web-tree-sitter and tree-sitter-wasms are optional peerDependencies.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { join, extname } from 'node:path';
+import { createRequire } from 'node:module';
+import type { ClassInfo, InterfaceInfo, FunctionInfo, MethodCallInfo } from './deep-scanner.js';
+import type { LanguageExtractor, ExtractedSymbols } from './language-extractor.js';
+
+// Re-export tree-sitter types for subclass use
+type TSParser = import('web-tree-sitter').Parser;
+type TSLanguage = import('web-tree-sitter').Language;
+type TSTree = import('web-tree-sitter').Tree;
+type TSNode = import('web-tree-sitter').Node;
+
+export type { TSNode, TSTree, TSLanguage };
+
+// ── WASM loading cache ──────────────────────────────────────────
+
+let parserClass: (new () => TSParser) | null = null;
+let languageClass: { load(input: string | Uint8Array): Promise<TSLanguage> } | null = null;
+let initialized = false;
+const languageCache = new Map<string, TSLanguage>();
+
+async function initTreeSitter(): Promise<boolean> {
+  if (initialized) return parserClass !== null;
+  try {
+    const mod = await import('web-tree-sitter');
+    const Parser = mod.default ?? mod;
+    await (Parser as any).init();
+    parserClass = Parser as unknown as new () => TSParser;
+    languageClass = (Parser as any).Language ?? mod.Language;
+    initialized = true;
+    return true;
+  } catch {
+    initialized = true;
+    return false;
+  }
+}
+
+async function loadLanguage(wasmName: string): Promise<TSLanguage | null> {
+  if (languageCache.has(wasmName)) return languageCache.get(wasmName)!;
+  if (!languageClass) return null;
+
+  try {
+    const require = createRequire(import.meta.url);
+    const wasmsDir = join(require.resolve('tree-sitter-wasms/package.json'), '..', 'out');
+    const wasmPath = join(wasmsDir, wasmName);
+    const wasmBuf = await readFile(wasmPath);
+    const lang = await languageClass.load(new Uint8Array(wasmBuf.buffer));
+    languageCache.set(wasmName, lang);
+    return lang;
+  } catch {
+    return null;
+  }
+}
+
+// ── Abstract base class ─────────────────────────────────────────
+
+export abstract class TreeSitterExtractor implements LanguageExtractor {
+  abstract readonly language: string;
+  abstract readonly extensions: string[];
+
+  /** WASM file name, e.g. 'tree-sitter-python.wasm' */
+  protected abstract readonly wasmName: string;
+
+  protected lang: TSLanguage | null = null;
+
+  async isAvailable(): Promise<boolean> {
+    const ok = await initTreeSitter();
+    if (!ok) return false;
+    this.lang = await loadLanguage(this.wasmName);
+    return this.lang !== null;
+  }
+
+  async extract(
+    filePaths: string[],
+    rootDir: string,
+    options: { maxSymbols: number; timeoutMs: number; includeMethodCalls: boolean },
+  ): Promise<ExtractedSymbols & { warnings: string[]; capped: boolean; fatal?: string }> {
+    if (!parserClass || !this.lang) {
+      return {
+        classes: [], interfaces: [], functions: [], methodCalls: [],
+        warnings: [], capped: false,
+        fatal: `Tree-sitter or ${this.wasmName} not available.`,
+      };
+    }
+
+    const parser = new parserClass();
+    parser.setLanguage(this.lang);
+
+    const start = Date.now();
+    const classes: ClassInfo[] = [];
+    const interfaces: InterfaceInfo[] = [];
+    const functions: FunctionInfo[] = [];
+    const methodCalls: MethodCallInfo[] = [];
+    const warnings: string[] = [];
+    let symbolCount = 0;
+    let capped = false;
+
+    const rootPrefix = rootDir.endsWith('/') ? rootDir : rootDir + '/';
+
+    for (const filePath of filePaths) {
+      if (Date.now() - start > options.timeoutMs) {
+        capped = true;
+        warnings.push(`Timeout after ${options.timeoutMs}ms. Returning partial results.`);
+        break;
+      }
+      if (symbolCount >= options.maxSymbols) {
+        capped = true;
+        break;
+      }
+
+      try {
+        const source = await readFile(filePath, 'utf-8');
+        const tree = parser.parse(source);
+        if (!tree) {
+          warnings.push(`Failed to parse ${filePath}`);
+          continue;
+        }
+
+        const relPath = filePath
+          .replace(rootPrefix, '')
+          .replace(new RegExp(`\\${extname(filePath)}$`), '');
+
+        const extracted = this.extractFromTree(tree, relPath, source, options.includeMethodCalls);
+
+        for (const c of extracted.classes) {
+          if (symbolCount >= options.maxSymbols) { capped = true; break; }
+          classes.push(c);
+          symbolCount += 1 + c.methods.length;
+        }
+        if (capped) break;
+
+        for (const i of extracted.interfaces) {
+          if (symbolCount >= options.maxSymbols) { capped = true; break; }
+          interfaces.push(i);
+          symbolCount++;
+        }
+        if (capped) break;
+
+        for (const f of extracted.functions) {
+          if (symbolCount >= options.maxSymbols) { capped = true; break; }
+          functions.push(f);
+          symbolCount++;
+        }
+        if (capped) break;
+
+        methodCalls.push(...extracted.methodCalls);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        warnings.push(`Skipped ${filePath}: ${msg}`);
+      }
+    }
+
+    parser.delete();
+
+    return { classes, interfaces, functions, methodCalls, warnings, capped };
+  }
+
+  /**
+   * Language-specific extraction from a parsed tree.
+   * Subclasses implement this to walk the AST and extract symbols.
+   */
+  protected abstract extractFromTree(
+    tree: TSTree,
+    relPath: string,
+    source: string,
+    includeMethodCalls: boolean,
+  ): ExtractedSymbols;
+
+  // ── Query helpers for subclasses ──────────────────────────────
+
+  /** Find all descendant nodes matching a type. */
+  protected findNodes(node: TSNode, type: string): TSNode[] {
+    const results: TSNode[] = [];
+    const walk = (n: TSNode) => {
+      if (n.type === type) results.push(n);
+      for (let i = 0; i < n.childCount; i++) {
+        walk(n.child(i)!);
+      }
+    };
+    walk(node);
+    return results;
+  }
+
+  /** Find first child of a specific type. */
+  protected findChild(node: TSNode, type: string): TSNode | null {
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i)!;
+      if (child.type === type) return child;
+    }
+    return null;
+  }
+
+  /** Find all direct children of a specific type. */
+  protected findChildren(node: TSNode, type: string): TSNode[] {
+    const results: TSNode[] = [];
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i)!;
+      if (child.type === type) results.push(child);
+    }
+    return results;
+  }
+
+  /** Get the text of a named child field. */
+  protected fieldText(node: TSNode, fieldName: string): string | null {
+    const child = node.childForFieldName(fieldName);
+    return child ? child.text : null;
+  }
+}

--- a/src/lib/deep-scanner-ts.ts
+++ b/src/lib/deep-scanner-ts.ts
@@ -1,0 +1,284 @@
+/**
+ * TypeScript/JavaScript extractor — uses ts-morph for symbol-level analysis.
+ * ts-morph is a peerDependency; when absent isAvailable() returns false.
+ */
+
+import type { ClassInfo, InterfaceInfo, FunctionInfo, MethodCallInfo } from './deep-scanner.js';
+import type { LanguageExtractor, ExtractedSymbols } from './language-extractor.js';
+
+// ── Dynamic import helper ───────────────────────────────────────
+
+type TsMorph = typeof import('ts-morph');
+
+async function tryImportTsMorph(): Promise<TsMorph | null> {
+  try {
+    return await import('ts-morph');
+  } catch {
+    return null;
+  }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+function qualifiedName(filePath: string, kind: string, name: string): string {
+  return `${filePath}/${kind}/${name}`;
+}
+
+function extractClasses(
+  sourceFile: import('ts-morph').SourceFile,
+  relPath: string,
+): ClassInfo[] {
+  const results: ClassInfo[] = [];
+  for (const cls of sourceFile.getClasses()) {
+    const name = cls.getName();
+    if (!name) continue;
+
+    let baseClass: string | null = null;
+    const baseNode = cls.getBaseClass();
+    if (baseNode) {
+      const baseName = baseNode.getName();
+      if (baseName) {
+        const baseSrc = baseNode.getSourceFile();
+        const baseRel = baseSrc === sourceFile
+          ? relPath
+          : baseSrc.getFilePath().replace(/.*?\/src\//, 'src/').replace(/\.[tj]sx?$/, '');
+        baseClass = qualifiedName(baseRel, 'class', baseName);
+      }
+    }
+
+    const interfaces: string[] = [];
+    for (const impl of cls.getImplements()) {
+      const sym = impl.getExpression().getSymbol();
+      if (sym) {
+        const decls = sym.getDeclarations();
+        if (decls.length > 0) {
+          const decl = decls[0];
+          const declFile = decl.getSourceFile();
+          const declRel = declFile === sourceFile
+            ? relPath
+            : declFile.getFilePath().replace(/.*?\/src\//, 'src/').replace(/\.[tj]sx?$/, '');
+          interfaces.push(qualifiedName(declRel, 'interface', sym.getName()));
+        } else {
+          interfaces.push(sym.getName());
+        }
+      }
+    }
+
+    const methods: ClassInfo['methods'] = [];
+    for (const method of cls.getMethods()) {
+      methods.push({
+        name: method.getName(),
+        returnType: method.getReturnType().getText(method),
+        parameters: method.getParameters().map(p => ({
+          name: p.getName(),
+          type: p.getType().getText(p),
+        })),
+      });
+    }
+
+    results.push({
+      name,
+      filePath: relPath,
+      baseClass,
+      interfaces,
+      methods,
+      isAbstract: cls.isAbstract(),
+    });
+  }
+  return results;
+}
+
+function extractInterfaces(
+  sourceFile: import('ts-morph').SourceFile,
+  relPath: string,
+): InterfaceInfo[] {
+  const results: InterfaceInfo[] = [];
+  for (const iface of sourceFile.getInterfaces()) {
+    const name = iface.getName();
+
+    const extendsArr: string[] = [];
+    for (const ext of iface.getExtends()) {
+      const sym = ext.getExpression().getSymbol();
+      if (sym) extendsArr.push(sym.getName());
+    }
+
+    const methods: Array<{ name: string; returnType: string }> = [];
+    for (const m of iface.getMethods()) {
+      methods.push({
+        name: m.getName(),
+        returnType: m.getReturnType().getText(m),
+      });
+    }
+
+    results.push({ name, filePath: relPath, extends: extendsArr, methods });
+  }
+  return results;
+}
+
+function extractFunctions(
+  sourceFile: import('ts-morph').SourceFile,
+  relPath: string,
+): FunctionInfo[] {
+  const results: FunctionInfo[] = [];
+  for (const fn of sourceFile.getFunctions()) {
+    const name = fn.getName();
+    if (!name) continue;
+    results.push({
+      name,
+      filePath: relPath,
+      returnType: fn.getReturnType().getText(fn),
+      parameters: fn.getParameters().map(p => ({
+        name: p.getName(),
+        type: p.getType().getText(p),
+      })),
+      isExported: fn.isExported(),
+    });
+  }
+  return results;
+}
+
+function extractMethodCalls(
+  sourceFile: import('ts-morph').SourceFile,
+  _relPath: string,
+  ts: TsMorph,
+): MethodCallInfo[] {
+  const results: MethodCallInfo[] = [];
+  const SyntaxKind = ts.SyntaxKind;
+
+  for (const cls of sourceFile.getClasses()) {
+    const className = cls.getName();
+    if (!className) continue;
+
+    for (const method of cls.getMethods()) {
+      const callerName = `${className}.${method.getName()}`;
+
+      method.forEachDescendant((node) => {
+        if (node.getKind() === SyntaxKind.CallExpression) {
+          const callExpr = node as import('ts-morph').CallExpression;
+          const expr = callExpr.getExpression();
+          if (expr.getKind() === SyntaxKind.PropertyAccessExpression) {
+            const propAccess = expr as import('ts-morph').PropertyAccessExpression;
+            const sym = propAccess.getSymbol();
+            if (sym) {
+              const decls = sym.getDeclarations();
+              if (decls.length > 0) {
+                const decl = decls[0];
+                const parent = decl.getParent();
+                if (parent && 'getName' in parent && typeof parent.getName === 'function') {
+                  const parentName = parent.getName() as string;
+                  if (parentName) {
+                    results.push({
+                      caller: callerName,
+                      callee: `${parentName}.${sym.getName()}`,
+                    });
+                  }
+                }
+              }
+            }
+          }
+        }
+      });
+    }
+  }
+  return results;
+}
+
+// ── TypeScriptExtractor ────────────────────────────────────────
+
+export class TypeScriptExtractor implements LanguageExtractor {
+  readonly language = 'typescript';
+  readonly extensions = ['.ts', '.tsx', '.js', '.jsx'];
+
+  private tsMorph: TsMorph | null = null;
+
+  async isAvailable(): Promise<boolean> {
+    this.tsMorph = await tryImportTsMorph();
+    return this.tsMorph !== null;
+  }
+
+  async extract(
+    _filePaths: string[],
+    rootDir: string,
+    options: { maxSymbols: number; timeoutMs: number; includeMethodCalls: boolean },
+  ): Promise<ExtractedSymbols & { warnings: string[]; capped: boolean; fatal?: string }> {
+    const ts = this.tsMorph ?? await tryImportTsMorph();
+    if (!ts) {
+      return { classes: [], interfaces: [], functions: [], methodCalls: [], warnings: ['ts-morph not available'], capped: false, fatal: 'ts-morph not installed. Run: npm install ts-morph' };
+    }
+
+    const { Project } = ts;
+    let project: InstanceType<typeof Project>;
+    try {
+      project = new Project({
+        tsConfigFilePath: `${rootDir}/tsconfig.json`,
+        skipAddingFilesFromTsConfig: false,
+        skipFileDependencyResolution: true,
+      });
+    } catch {
+      return { classes: [], interfaces: [], functions: [], methodCalls: [], warnings: [], capped: false, fatal: `Failed to load tsconfig.json from ${rootDir}` };
+    }
+
+    const sourceFiles = project.getSourceFiles()
+      .filter(sf => !sf.getFilePath().includes('node_modules'))
+      .filter(sf => !sf.getFilePath().includes('/dist/'));
+
+    const start = Date.now();
+    const classes: ClassInfo[] = [];
+    const interfaces: InterfaceInfo[] = [];
+    const functions: FunctionInfo[] = [];
+    const methodCalls: MethodCallInfo[] = [];
+    const warnings: string[] = [];
+    let symbolCount = 0;
+    let capped = false;
+
+    for (const sf of sourceFiles) {
+      if (Date.now() - start > options.timeoutMs) {
+        capped = true;
+        warnings.push(`Timeout after ${options.timeoutMs}ms. Returning partial results.`);
+        break;
+      }
+
+      const fullPath = sf.getFilePath();
+      const relPath = fullPath
+        .replace(rootDir.endsWith('/') ? rootDir : rootDir + '/', '')
+        .replace(/\.[tj]sx?$/, '');
+
+      try {
+        const cls = extractClasses(sf, relPath);
+        for (const c of cls) {
+          if (symbolCount >= options.maxSymbols) { capped = true; break; }
+          classes.push(c);
+          symbolCount++;
+          symbolCount += c.methods.length;
+        }
+        if (capped) break;
+
+        const ifaces = extractInterfaces(sf, relPath);
+        for (const i of ifaces) {
+          if (symbolCount >= options.maxSymbols) { capped = true; break; }
+          interfaces.push(i);
+          symbolCount++;
+        }
+        if (capped) break;
+
+        const fns = extractFunctions(sf, relPath);
+        for (const f of fns) {
+          if (symbolCount >= options.maxSymbols) { capped = true; break; }
+          functions.push(f);
+          symbolCount++;
+        }
+        if (capped) break;
+
+        if (options.includeMethodCalls) {
+          const calls = extractMethodCalls(sf, relPath, ts);
+          methodCalls.push(...calls);
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        warnings.push(`Skipped ${relPath}: ${msg}`);
+      }
+    }
+
+    return { classes, interfaces, functions, methodCalls, warnings, capped };
+  }
+}

--- a/src/lib/deep-scanner.ts
+++ b/src/lib/deep-scanner.ts
@@ -1,7 +1,15 @@
 /**
- * Deep scanner — symbol-level codebase analysis using ts-morph.
- * ts-morph is a peerDependency; when absent the scan gracefully degrades.
+ * Deep scanner — language-agnostic orchestrator for symbol-level codebase analysis.
+ * Delegates to LanguageExtractor implementations (ts-morph, tree-sitter, etc.).
  */
+
+import type { LanguageExtractor } from './language-extractor.js';
+import { TypeScriptExtractor } from './deep-scanner-ts.js';
+import { PythonExtractor } from './extractors/python.js';
+import { GoExtractor } from './extractors/go.js';
+import { RustExtractor } from './extractors/rust.js';
+import { JavaExtractor } from './extractors/java.js';
+import { SwiftExtractor } from './extractors/swift.js';
 
 // ── Exported types ──────────────────────────────────────────────
 
@@ -10,6 +18,7 @@ export interface DeepScanOptions {
   maxSymbols?: number;          // default 300
   timeoutMs?: number;           // default 30_000
   includeMethodCalls?: boolean; // default false
+  languages?: string[];         // e.g. ['typescript', 'python'] — auto-detect if omitted
 }
 
 export interface MethodInfo {
@@ -68,181 +77,55 @@ export interface DeepScanUnavailable {
 
 export type DeepScanOutput = DeepScanResult | DeepScanUnavailable;
 
-// ── Dynamic import helper ───────────────────────────────────────
+// ── Extractor registry ─────────────────────────────────────────
 
-type TsMorph = typeof import('ts-morph');
+/** All known extractors. Add new languages here. */
+function getAllExtractors(): LanguageExtractor[] {
+  return [
+    new TypeScriptExtractor(),
+    new PythonExtractor(),
+    new GoExtractor(),
+    new RustExtractor(),
+    new JavaExtractor(),
+    new SwiftExtractor(),
+  ];
+}
 
-async function tryImportTsMorph(): Promise<TsMorph | null> {
+function detectLanguages(rootDir: string, extractors: LanguageExtractor[]): LanguageExtractor[] {
+  // For now, return all available extractors.
+  // Future: scan rootDir for file extensions and filter.
+  return extractors;
+}
+
+// ── File discovery ─────────────────────────────────────────────
+
+async function discoverFiles(
+  rootDir: string,
+  extensions: string[],
+  maxFiles: number,
+): Promise<{ files: string[]; total: number }> {
+  const { execSync } = await import('node:child_process');
+
+  // Use git ls-files if inside a git repo, otherwise fall back to find
+  const extGlob = extensions.map(e => `*${e}`);
+  let stdout: string;
   try {
-    return await import('ts-morph');
+    stdout = execSync(
+      `git -C "${rootDir}" ls-files -- ${extGlob.map(g => `'${g}'`).join(' ')}`,
+      { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 },
+    );
   } catch {
-    return null;
+    // Not a git repo — fall back
+    const patterns = extensions.map(e => `-name '*${e}'`).join(' -o ');
+    stdout = execSync(
+      `find "${rootDir}" -type f \\( ${patterns} \\) -not -path '*/node_modules/*' -not -path '*/dist/*'`,
+      { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 },
+    );
   }
-}
 
-// ── Extractors ──────────────────────────────────────────────────
-
-function qualifiedName(filePath: string, kind: string, name: string): string {
-  return `${filePath}/${kind}/${name}`;
-}
-
-function extractClasses(
-  sourceFile: import('ts-morph').SourceFile,
-  relPath: string,
-): ClassInfo[] {
-  const results: ClassInfo[] = [];
-  for (const cls of sourceFile.getClasses()) {
-    const name = cls.getName();
-    if (!name) continue;
-
-    let baseClass: string | null = null;
-    const baseNode = cls.getBaseClass();
-    if (baseNode) {
-      const baseName = baseNode.getName();
-      if (baseName) {
-        const baseSrc = baseNode.getSourceFile();
-        const baseRel = baseSrc === sourceFile
-          ? relPath
-          : baseSrc.getFilePath().replace(/.*?\/src\//, 'src/').replace(/\.[tj]sx?$/, '');
-        baseClass = qualifiedName(baseRel, 'class', baseName);
-      }
-    }
-
-    const interfaces: string[] = [];
-    for (const impl of cls.getImplements()) {
-      const sym = impl.getExpression().getSymbol();
-      if (sym) {
-        const decls = sym.getDeclarations();
-        if (decls.length > 0) {
-          const decl = decls[0];
-          const declFile = decl.getSourceFile();
-          const declRel = declFile === sourceFile
-            ? relPath
-            : declFile.getFilePath().replace(/.*?\/src\//, 'src/').replace(/\.[tj]sx?$/, '');
-          interfaces.push(qualifiedName(declRel, 'interface', sym.getName()));
-        } else {
-          interfaces.push(sym.getName());
-        }
-      }
-    }
-
-    const methods: MethodInfo[] = [];
-    for (const method of cls.getMethods()) {
-      methods.push({
-        name: method.getName(),
-        returnType: method.getReturnType().getText(method),
-        parameters: method.getParameters().map(p => ({
-          name: p.getName(),
-          type: p.getType().getText(p),
-        })),
-      });
-    }
-
-    results.push({
-      name,
-      filePath: relPath,
-      baseClass,
-      interfaces,
-      methods,
-      isAbstract: cls.isAbstract(),
-    });
-  }
-  return results;
-}
-
-function extractInterfaces(
-  sourceFile: import('ts-morph').SourceFile,
-  relPath: string,
-): InterfaceInfo[] {
-  const results: InterfaceInfo[] = [];
-  for (const iface of sourceFile.getInterfaces()) {
-    const name = iface.getName();
-
-    const extendsArr: string[] = [];
-    for (const ext of iface.getExtends()) {
-      const sym = ext.getExpression().getSymbol();
-      if (sym) extendsArr.push(sym.getName());
-    }
-
-    const methods: Array<{ name: string; returnType: string }> = [];
-    for (const m of iface.getMethods()) {
-      methods.push({
-        name: m.getName(),
-        returnType: m.getReturnType().getText(m),
-      });
-    }
-
-    results.push({ name, filePath: relPath, extends: extendsArr, methods });
-  }
-  return results;
-}
-
-function extractFunctions(
-  sourceFile: import('ts-morph').SourceFile,
-  relPath: string,
-): FunctionInfo[] {
-  const results: FunctionInfo[] = [];
-  for (const fn of sourceFile.getFunctions()) {
-    const name = fn.getName();
-    if (!name) continue;
-    results.push({
-      name,
-      filePath: relPath,
-      returnType: fn.getReturnType().getText(fn),
-      parameters: fn.getParameters().map(p => ({
-        name: p.getName(),
-        type: p.getType().getText(p),
-      })),
-      isExported: fn.isExported(),
-    });
-  }
-  return results;
-}
-
-function extractMethodCalls(
-  sourceFile: import('ts-morph').SourceFile,
-  relPath: string,
-  ts: TsMorph,
-): MethodCallInfo[] {
-  const results: MethodCallInfo[] = [];
-  const SyntaxKind = ts.SyntaxKind;
-
-  for (const cls of sourceFile.getClasses()) {
-    const className = cls.getName();
-    if (!className) continue;
-
-    for (const method of cls.getMethods()) {
-      const callerName = `${className}.${method.getName()}`;
-
-      method.forEachDescendant((node) => {
-        if (node.getKind() === SyntaxKind.CallExpression) {
-          const callExpr = node as import('ts-morph').CallExpression;
-          const expr = callExpr.getExpression();
-          if (expr.getKind() === SyntaxKind.PropertyAccessExpression) {
-            const propAccess = expr as import('ts-morph').PropertyAccessExpression;
-            const sym = propAccess.getSymbol();
-            if (sym) {
-              const decls = sym.getDeclarations();
-              if (decls.length > 0) {
-                const decl = decls[0];
-                const parent = decl.getParent();
-                if (parent && 'getName' in parent && typeof parent.getName === 'function') {
-                  const parentName = parent.getName() as string;
-                  if (parentName) {
-                    results.push({
-                      caller: callerName,
-                      callee: `${parentName}.${sym.getName()}`,
-                    });
-                  }
-                }
-              }
-            }
-          }
-        }
-      });
-    }
-  }
-  return results;
+  const allFiles = stdout.trim().split('\n').filter(Boolean)
+    .filter(f => !f.includes('node_modules') && !f.includes('/dist/'));
+  return { files: allFiles.slice(0, maxFiles), total: allFiles.length };
 }
 
 // ── Main entry point ────────────────────────────────────────────
@@ -251,114 +134,119 @@ export async function deepScan(
   rootDir: string,
   options?: DeepScanOptions,
 ): Promise<DeepScanOutput> {
-  const ts = await tryImportTsMorph();
-  if (!ts) {
-    return {
-      deepScanAvailable: false,
-      error: 'ts-morph not installed. Run: npm install ts-morph',
-      fallback: null,
-    };
-  }
-
   const maxFiles = options?.maxFiles ?? 500;
   const maxSymbols = options?.maxSymbols ?? 300;
   const timeoutMs = options?.timeoutMs ?? 30_000;
   const includeMethodCalls = options?.includeMethodCalls ?? false;
+  const requestedLanguages = options?.languages;
 
   const start = Date.now();
-  const warnings: string[] = [];
 
-  // Initialise ts-morph Project
-  const { Project } = ts;
-  let project: InstanceType<typeof Project>;
-  try {
-    project = new Project({
-      tsConfigFilePath: `${rootDir}/tsconfig.json`,
-      skipAddingFilesFromTsConfig: false,
-      skipFileDependencyResolution: true,
-    });
-  } catch {
+  // Resolve extractors
+  let allExtractors = getAllExtractors();
+  if (requestedLanguages) {
+    allExtractors = allExtractors.filter(e => requestedLanguages.includes(e.language));
+  }
+
+  // Check availability
+  const available: LanguageExtractor[] = [];
+  for (const ext of allExtractors) {
+    if (await ext.isAvailable()) {
+      available.push(ext);
+    }
+  }
+
+  if (available.length === 0) {
     return {
       deepScanAvailable: false,
-      error: `Failed to load tsconfig.json from ${rootDir}`,
+      error: requestedLanguages
+        ? `No extractors available for: ${requestedLanguages.join(', ')}. Install required dependencies.`
+        : 'No language extractors available. Install ts-morph for TypeScript support.',
       fallback: null,
     };
   }
 
-  const sourceFiles = project.getSourceFiles()
-    .filter(sf => !sf.getFilePath().includes('node_modules'))
-    .filter(sf => !sf.getFilePath().includes('/dist/'));
+  // Collect all extensions from available extractors
+  const allExtensions = available.flatMap(e => e.extensions);
 
-  if (sourceFiles.length > maxFiles) {
+  // Discover files
+  const { files, total } = await discoverFiles(rootDir, allExtensions, maxFiles);
+
+  if (total > maxFiles) {
     return {
       deepScanAvailable: true,
       classes: [],
       interfaces: [],
       functions: [],
       methodCalls: [],
-      fileCount: sourceFiles.length,
+      fileCount: total,
       symbolCount: 0,
       scanDurationMs: Date.now() - start,
       capped: true,
-      warnings: [`File count ${sourceFiles.length} exceeds maxFiles ${maxFiles}. Scan skipped.`],
+      warnings: [`File count ${total} exceeds maxFiles ${maxFiles}. Scan skipped.`],
     };
   }
 
+  // Group files by extractor
+  const filesByExtractor = new Map<LanguageExtractor, string[]>();
+  for (const ext of available) {
+    filesByExtractor.set(ext, []);
+  }
+  for (const file of files) {
+    for (const ext of available) {
+      if (ext.extensions.some(e => file.endsWith(e))) {
+        filesByExtractor.get(ext)!.push(file);
+        break;
+      }
+    }
+  }
+
+  // Run extractors
   const classes: ClassInfo[] = [];
   const interfaces: InterfaceInfo[] = [];
   const functions: FunctionInfo[] = [];
   const methodCalls: MethodCallInfo[] = [];
-  let symbolCount = 0;
+  const warnings: string[] = [];
   let capped = false;
 
-  for (const sf of sourceFiles) {
-    if (Date.now() - start > timeoutMs) {
+  for (const [extractor, extFiles] of filesByExtractor) {
+    if (extFiles.length === 0) continue;
+    if (capped) break;
+
+    const remainingTime = timeoutMs - (Date.now() - start);
+    if (remainingTime <= 0) {
       capped = true;
-      warnings.push(`Timeout after ${timeoutMs}ms. Returning partial results.`);
+      warnings.push(`Timeout before running ${extractor.language} extractor.`);
       break;
     }
 
-    const fullPath = sf.getFilePath();
-    const relPath = fullPath
-      .replace(rootDir.endsWith('/') ? rootDir : rootDir + '/', '')
-      .replace(/\.[tj]sx?$/, '');
+    const result = await extractor.extract(extFiles, rootDir, {
+      maxSymbols,
+      timeoutMs: remainingTime,
+      includeMethodCalls,
+    });
 
-    try {
-      const cls = extractClasses(sf, relPath);
-      for (const c of cls) {
-        if (symbolCount >= maxSymbols) { capped = true; break; }
-        classes.push(c);
-        symbolCount++;
-        // Count methods as symbols too
-        symbolCount += c.methods.length;
-      }
-      if (capped) break;
-
-      const ifaces = extractInterfaces(sf, relPath);
-      for (const i of ifaces) {
-        if (symbolCount >= maxSymbols) { capped = true; break; }
-        interfaces.push(i);
-        symbolCount++;
-      }
-      if (capped) break;
-
-      const fns = extractFunctions(sf, relPath);
-      for (const f of fns) {
-        if (symbolCount >= maxSymbols) { capped = true; break; }
-        functions.push(f);
-        symbolCount++;
-      }
-      if (capped) break;
-
-      if (includeMethodCalls) {
-        const calls = extractMethodCalls(sf, relPath, ts);
-        methodCalls.push(...calls);
-      }
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      warnings.push(`Skipped ${relPath}: ${msg}`);
+    // If the only extractor reports a fatal error, propagate as unavailable
+    if (result.fatal && available.length === 1) {
+      return {
+        deepScanAvailable: false,
+        error: result.fatal,
+        fallback: null,
+      };
     }
+
+    classes.push(...result.classes);
+    interfaces.push(...result.interfaces);
+    functions.push(...result.functions);
+    methodCalls.push(...result.methodCalls);
+    warnings.push(...result.warnings);
+    if (result.fatal) warnings.push(`${extractor.language}: ${result.fatal}`);
+    if (result.capped) capped = true;
   }
+
+  const symbolCount = classes.reduce((n, c) => n + 1 + c.methods.length, 0)
+    + interfaces.length
+    + functions.length;
 
   return {
     deepScanAvailable: true,
@@ -366,7 +254,7 @@ export async function deepScan(
     interfaces,
     functions,
     methodCalls,
-    fileCount: sourceFiles.length,
+    fileCount: files.length,
     symbolCount,
     scanDurationMs: Date.now() - start,
     capped,

--- a/src/lib/extractors/go.ts
+++ b/src/lib/extractors/go.ts
@@ -1,0 +1,182 @@
+/**
+ * Go extractor — uses Tree-sitter to extract structs, interfaces, functions, and method calls.
+ * Go structs → ClassInfo, Go interfaces → InterfaceInfo.
+ */
+
+import { TreeSitterExtractor } from '../deep-scanner-treesitter.js';
+import type { TSNode, TSTree } from '../deep-scanner-treesitter.js';
+import type { ExtractedSymbols } from '../language-extractor.js';
+import type { ClassInfo, InterfaceInfo, FunctionInfo, MethodCallInfo } from '../deep-scanner.js';
+
+export class GoExtractor extends TreeSitterExtractor {
+  readonly language = 'go';
+  readonly extensions = ['.go'];
+  protected readonly wasmName = 'tree-sitter-go.wasm';
+
+  protected extractFromTree(
+    tree: TSTree,
+    relPath: string,
+    _source: string,
+    includeMethodCalls: boolean,
+  ): ExtractedSymbols {
+    const classes: ClassInfo[] = [];
+    const interfaces: InterfaceInfo[] = [];
+    const functions: FunctionInfo[] = [];
+    const methodCalls: MethodCallInfo[] = [];
+    const root = tree.rootNode;
+
+    // ── Type declarations ──
+    for (const typeDecl of this.findNodes(root, 'type_declaration')) {
+      for (const typeSpec of this.findChildren(typeDecl, 'type_spec')) {
+        const name = this.fieldText(typeSpec, 'name');
+        if (!name) continue;
+        const typeNode = typeSpec.childForFieldName('type');
+        if (!typeNode) continue;
+
+        if (typeNode.type === 'struct_type') {
+          const { embedded, methods: fieldMethods } = this.extractStructFields(typeNode);
+          classes.push({
+            name,
+            filePath: relPath,
+            baseClass: embedded.length > 0 ? embedded[0] : null,
+            interfaces: [],
+            methods: fieldMethods,
+            isAbstract: false,
+          });
+        } else if (typeNode.type === 'interface_type') {
+          const methods = this.extractInterfaceMethods(typeNode);
+          const extendsArr = this.extractInterfaceEmbeds(typeNode);
+          interfaces.push({
+            name,
+            filePath: relPath,
+            extends: extendsArr,
+            methods,
+          });
+        }
+      }
+    }
+
+    // ── Functions and methods ──
+    for (const fn of this.findNodes(root, 'function_declaration')) {
+      const name = this.fieldText(fn, 'name');
+      if (!name) continue;
+
+      functions.push({
+        name,
+        filePath: relPath,
+        returnType: this.getReturnType(fn),
+        parameters: this.extractParams(fn),
+        isExported: name[0] === name[0].toUpperCase(),
+      });
+    }
+
+    // ── Method declarations (receiver functions) ──
+    for (const method of this.findNodes(root, 'method_declaration')) {
+      const name = this.fieldText(method, 'name');
+      if (!name) continue;
+
+      const receiver = this.getReceiverType(method);
+      if (receiver) {
+        const cls = classes.find(c => c.name === receiver);
+        if (cls) {
+          cls.methods.push({
+            name,
+            returnType: this.getReturnType(method),
+            parameters: this.extractParams(method),
+          });
+        }
+      }
+
+      if (includeMethodCalls && receiver) {
+        const callerName = `${receiver}.${name}`;
+        for (const call of this.findNodes(method, 'call_expression')) {
+          const fnNode = call.childForFieldName('function');
+          if (fnNode && fnNode.type === 'selector_expression') {
+            const operand = fnNode.childForFieldName('operand');
+            const field = fnNode.childForFieldName('field');
+            if (operand && field) {
+              methodCalls.push({
+                caller: callerName,
+                callee: `${operand.text}.${field.text}`,
+              });
+            }
+          }
+        }
+      }
+    }
+
+    return { classes, interfaces, functions, methodCalls };
+  }
+
+  private extractStructFields(structNode: TSNode): { embedded: string[]; methods: ClassInfo['methods'] } {
+    const embedded: string[] = [];
+    const fieldList = this.findChild(structNode, 'field_declaration_list');
+    if (!fieldList) return { embedded, methods: [] };
+
+    for (const field of this.findChildren(fieldList, 'field_declaration')) {
+      // Embedded struct: no field name, just a type
+      const nameNode = field.childForFieldName('name');
+      const typeNode = field.childForFieldName('type');
+      if (!nameNode && typeNode) {
+        embedded.push(typeNode.text);
+      }
+    }
+    return { embedded, methods: [] };
+  }
+
+  private extractInterfaceMethods(ifaceNode: TSNode): Array<{ name: string; returnType: string }> {
+    const methods: Array<{ name: string; returnType: string }> = [];
+    // Interface methods are method_spec nodes inside the interface body
+    for (const spec of this.findNodes(ifaceNode, 'method_spec')) {
+      const name = this.fieldText(spec, 'name');
+      if (name) {
+        methods.push({ name, returnType: this.getReturnType(spec) });
+      }
+    }
+    return methods;
+  }
+
+  private extractInterfaceEmbeds(ifaceNode: TSNode): string[] {
+    const embeds: string[] = [];
+    // Embedded interfaces appear as type_name or qualified_type inside interface body
+    for (const child of this.findNodes(ifaceNode, 'type_name')) {
+      embeds.push(child.text);
+    }
+    return embeds;
+  }
+
+  private getReceiverType(method: TSNode): string | null {
+    const receiver = method.childForFieldName('receiver');
+    if (!receiver) return null;
+    // Walk through parameter list to find the type
+    const paramList = this.findChild(receiver, 'parameter_list');
+    if (!paramList) return null;
+    for (let i = 0; i < paramList.childCount; i++) {
+      const param = paramList.child(i)!;
+      const typeNode = param.childForFieldName('type');
+      if (typeNode) {
+        // Strip pointer: *Foo → Foo
+        return typeNode.text.replace(/^\*/, '');
+      }
+    }
+    return null;
+  }
+
+  private extractParams(fn: TSNode): Array<{ name: string; type: string }> {
+    const params: Array<{ name: string; type: string }> = [];
+    const paramList = fn.childForFieldName('parameters');
+    if (!paramList) return params;
+
+    for (const param of this.findNodes(paramList, 'parameter_declaration')) {
+      const name = this.fieldText(param, 'name') ?? '';
+      const typeNode = param.childForFieldName('type');
+      params.push({ name, type: typeNode?.text ?? '' });
+    }
+    return params;
+  }
+
+  private getReturnType(fn: TSNode): string {
+    const result = fn.childForFieldName('result');
+    return result ? result.text : 'void';
+  }
+}

--- a/src/lib/extractors/java.ts
+++ b/src/lib/extractors/java.ts
@@ -1,0 +1,164 @@
+/**
+ * Java extractor — uses Tree-sitter to extract classes, interfaces, methods, and calls.
+ * Direct mapping: Java class → ClassInfo, Java interface → InterfaceInfo.
+ */
+
+import { TreeSitterExtractor } from '../deep-scanner-treesitter.js';
+import type { TSNode, TSTree } from '../deep-scanner-treesitter.js';
+import type { ExtractedSymbols } from '../language-extractor.js';
+import type { ClassInfo, InterfaceInfo, FunctionInfo, MethodCallInfo } from '../deep-scanner.js';
+
+export class JavaExtractor extends TreeSitterExtractor {
+  readonly language = 'java';
+  readonly extensions = ['.java'];
+  protected readonly wasmName = 'tree-sitter-java.wasm';
+
+  protected extractFromTree(
+    tree: TSTree,
+    relPath: string,
+    _source: string,
+    includeMethodCalls: boolean,
+  ): ExtractedSymbols {
+    const classes: ClassInfo[] = [];
+    const interfaces: InterfaceInfo[] = [];
+    const functions: FunctionInfo[] = [];
+    const methodCalls: MethodCallInfo[] = [];
+    const root = tree.rootNode;
+
+    // ── Classes ──
+    for (const node of this.findNodes(root, 'class_declaration')) {
+      const name = this.fieldText(node, 'name');
+      if (!name) continue;
+
+      const superclass = this.getSuperclass(node);
+      const ifaces = this.getImplementedInterfaces(node);
+      const methods = this.extractMethods(node);
+      const isAbstract = this.hasModifier(node, 'abstract');
+
+      classes.push({
+        name,
+        filePath: relPath,
+        baseClass: superclass,
+        interfaces: ifaces,
+        methods,
+        isAbstract,
+      });
+
+      if (includeMethodCalls) {
+        for (const method of this.findNodes(node, 'method_declaration')) {
+          const methodName = this.fieldText(method, 'name');
+          if (!methodName) continue;
+          const callerName = `${name}.${methodName}`;
+
+          for (const call of this.findNodes(method, 'method_invocation')) {
+            const obj = call.childForFieldName('object');
+            const methodRef = call.childForFieldName('name');
+            if (obj && methodRef) {
+              methodCalls.push({
+                caller: callerName,
+                callee: `${obj.text}.${methodRef.text}`,
+              });
+            }
+          }
+        }
+      }
+    }
+
+    // ── Interfaces ──
+    for (const node of this.findNodes(root, 'interface_declaration')) {
+      const name = this.fieldText(node, 'name');
+      if (!name) continue;
+
+      const extendsArr = this.getExtendsInterfaces(node);
+      const methods: Array<{ name: string; returnType: string }> = [];
+
+      for (const method of this.findNodes(node, 'method_declaration')) {
+        const methodName = this.fieldText(method, 'name');
+        const retType = this.getMethodReturnType(method);
+        if (methodName) {
+          methods.push({ name: methodName, returnType: retType });
+        }
+      }
+
+      interfaces.push({ name, filePath: relPath, extends: extendsArr, methods });
+    }
+
+    return { classes, interfaces, functions, methodCalls };
+  }
+
+  private getSuperclass(node: TSNode): string | null {
+    const superclass = node.childForFieldName('superclass');
+    if (!superclass) return null;
+    // superclass node wraps the type name
+    const typeNode = this.findChild(superclass, 'type_identifier');
+    return typeNode?.text ?? superclass.text.replace(/^extends\s+/, '');
+  }
+
+  private getImplementedInterfaces(node: TSNode): string[] {
+    const result: string[] = [];
+    const interfaces = node.childForFieldName('interfaces');
+    if (!interfaces) return result;
+    for (const typeId of this.findNodes(interfaces, 'type_identifier')) {
+      result.push(typeId.text);
+    }
+    return result;
+  }
+
+  private getExtendsInterfaces(node: TSNode): string[] {
+    const result: string[] = [];
+    // Look for extends_interfaces or type_list after 'extends'
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i)!;
+      if (child.type === 'extends_interfaces' || child.type === 'type_list') {
+        for (const typeId of this.findNodes(child, 'type_identifier')) {
+          result.push(typeId.text);
+        }
+      }
+    }
+    return result;
+  }
+
+  private extractMethods(classNode: TSNode): ClassInfo['methods'] {
+    const methods: ClassInfo['methods'] = [];
+    const body = this.findChild(classNode, 'class_body');
+    if (!body) return methods;
+
+    for (const method of this.findChildren(body, 'method_declaration')) {
+      const name = this.fieldText(method, 'name');
+      if (!name) continue;
+
+      methods.push({
+        name,
+        returnType: this.getMethodReturnType(method),
+        parameters: this.extractParams(method),
+      });
+    }
+    return methods;
+  }
+
+  private extractParams(method: TSNode): Array<{ name: string; type: string }> {
+    const params: Array<{ name: string; type: string }> = [];
+    const paramList = method.childForFieldName('parameters');
+    if (!paramList) return params;
+
+    for (const param of this.findNodes(paramList, 'formal_parameter')) {
+      const name = this.fieldText(param, 'name');
+      const typeNode = param.childForFieldName('type');
+      if (name) {
+        params.push({ name, type: typeNode?.text ?? '' });
+      }
+    }
+    return params;
+  }
+
+  private getMethodReturnType(method: TSNode): string {
+    const typeNode = method.childForFieldName('type');
+    return typeNode?.text ?? 'void';
+  }
+
+  private hasModifier(node: TSNode, modifier: string): boolean {
+    const modifiers = this.findChild(node, 'modifiers');
+    if (!modifiers) return false;
+    return modifiers.text.includes(modifier);
+  }
+}

--- a/src/lib/extractors/python.ts
+++ b/src/lib/extractors/python.ts
@@ -1,0 +1,169 @@
+/**
+ * Python extractor — uses Tree-sitter to extract classes, functions, and method calls.
+ * Maps Python ABC/Protocol subclasses to InterfaceInfo.
+ */
+
+import { TreeSitterExtractor } from '../deep-scanner-treesitter.js';
+import type { TSNode, TSTree } from '../deep-scanner-treesitter.js';
+import type { ExtractedSymbols } from '../language-extractor.js';
+import type { ClassInfo, InterfaceInfo, FunctionInfo, MethodCallInfo } from '../deep-scanner.js';
+
+const PROTOCOL_BASES = new Set(['ABC', 'ABCMeta', 'Protocol']);
+
+export class PythonExtractor extends TreeSitterExtractor {
+  readonly language = 'python';
+  readonly extensions = ['.py'];
+  protected readonly wasmName = 'tree-sitter-python.wasm';
+
+  protected extractFromTree(
+    tree: TSTree,
+    relPath: string,
+    _source: string,
+    includeMethodCalls: boolean,
+  ): ExtractedSymbols {
+    const classes: ClassInfo[] = [];
+    const interfaces: InterfaceInfo[] = [];
+    const functions: FunctionInfo[] = [];
+    const methodCalls: MethodCallInfo[] = [];
+    const root = tree.rootNode;
+
+    // ── Classes ──
+    for (const node of this.findNodes(root, 'class_definition')) {
+      const name = this.fieldText(node, 'name');
+      if (!name) continue;
+
+      const bases = this.getBaseClasses(node);
+      const isProtocol = bases.some(b => PROTOCOL_BASES.has(b));
+      const methods = this.extractMethods(node, relPath);
+
+      if (isProtocol) {
+        interfaces.push({
+          name,
+          filePath: relPath,
+          extends: bases.filter(b => !PROTOCOL_BASES.has(b)),
+          methods: methods.map(m => ({ name: m.name, returnType: m.returnType })),
+        });
+      } else {
+        classes.push({
+          name,
+          filePath: relPath,
+          baseClass: bases.length > 0 ? bases[0] : null,
+          interfaces: bases.filter(b => PROTOCOL_BASES.has(b)),
+          methods,
+          isAbstract: this.hasAbstractDecorator(node),
+        });
+      }
+
+      // ── Method calls ──
+      if (includeMethodCalls) {
+        for (const method of this.findChildren(this.findChild(node, 'block') ?? node, 'function_definition')) {
+          const methodName = this.fieldText(method, 'name');
+          if (!methodName || methodName.startsWith('_')) continue;
+          const callerName = `${name}.${methodName}`;
+
+          for (const call of this.findNodes(method, 'call')) {
+            const fn = call.childForFieldName('function');
+            if (fn && fn.type === 'attribute') {
+              const obj = fn.childForFieldName('object');
+              const attr = fn.childForFieldName('attribute');
+              if (obj && attr) {
+                methodCalls.push({
+                  caller: callerName,
+                  callee: `${obj.text}.${attr.text}`,
+                });
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // ── Top-level functions ──
+    for (const node of this.findChildren(root, 'function_definition')) {
+      const name = this.fieldText(node, 'name');
+      if (!name) continue;
+
+      const params = this.extractParams(node);
+      const returnType = this.getReturnAnnotation(node);
+      const isDecorated = this.findChildren(node.parent ?? root, 'decorator').length > 0;
+
+      functions.push({
+        name,
+        filePath: relPath,
+        returnType,
+        parameters: params,
+        isExported: !name.startsWith('_'),
+      });
+    }
+
+    return { classes, interfaces, functions, methodCalls };
+  }
+
+  private getBaseClasses(node: TSNode): string[] {
+    const argList = this.findChild(node, 'argument_list');
+    if (!argList) return [];
+    const bases: string[] = [];
+    for (let i = 0; i < argList.childCount; i++) {
+      const child = argList.child(i)!;
+      if (child.type === 'identifier' || child.type === 'attribute') {
+        bases.push(child.text);
+      }
+    }
+    return bases;
+  }
+
+  private hasAbstractDecorator(node: TSNode): boolean {
+    // Check preceding siblings for decorators
+    let sibling = node.previousSibling;
+    while (sibling) {
+      if (sibling.type === 'decorator') {
+        const text = sibling.text;
+        if (text.includes('abstractmethod') || text.includes('ABC')) return true;
+      }
+      if (sibling.type !== 'decorator' && sibling.type !== 'comment') break;
+      sibling = sibling.previousSibling;
+    }
+    return false;
+  }
+
+  private extractMethods(classNode: TSNode, _relPath: string): ClassInfo['methods'] {
+    const block = this.findChild(classNode, 'block');
+    if (!block) return [];
+
+    const methods: ClassInfo['methods'] = [];
+    for (const fn of this.findChildren(block, 'function_definition')) {
+      const name = this.fieldText(fn, 'name');
+      if (!name || name === '__init__') continue;
+
+      methods.push({
+        name,
+        returnType: this.getReturnAnnotation(fn),
+        parameters: this.extractParams(fn).filter(p => p.name !== 'self' && p.name !== 'cls'),
+      });
+    }
+    return methods;
+  }
+
+  private extractParams(fn: TSNode): Array<{ name: string; type: string }> {
+    const params: Array<{ name: string; type: string }> = [];
+    const paramList = this.findChild(fn, 'parameters');
+    if (!paramList) return params;
+
+    for (let i = 0; i < paramList.childCount; i++) {
+      const p = paramList.child(i)!;
+      if (p.type === 'identifier') {
+        params.push({ name: p.text, type: 'Any' });
+      } else if (p.type === 'typed_parameter') {
+        const name = this.fieldText(p, 'name') ?? p.child(0)?.text ?? '';
+        const typeNode = p.childForFieldName('type');
+        params.push({ name, type: typeNode?.text ?? 'Any' });
+      }
+    }
+    return params;
+  }
+
+  private getReturnAnnotation(fn: TSNode): string {
+    const retType = fn.childForFieldName('return_type');
+    return retType ? retType.text : 'None';
+  }
+}

--- a/src/lib/extractors/rust.ts
+++ b/src/lib/extractors/rust.ts
@@ -1,0 +1,195 @@
+/**
+ * Rust extractor — uses Tree-sitter to extract structs, traits, functions, and impl blocks.
+ * Rust structs → ClassInfo, Rust traits → InterfaceInfo, impl Trait for Struct → interfaces[].
+ */
+
+import { TreeSitterExtractor } from '../deep-scanner-treesitter.js';
+import type { TSNode, TSTree } from '../deep-scanner-treesitter.js';
+import type { ExtractedSymbols } from '../language-extractor.js';
+import type { ClassInfo, InterfaceInfo, FunctionInfo, MethodCallInfo } from '../deep-scanner.js';
+
+export class RustExtractor extends TreeSitterExtractor {
+  readonly language = 'rust';
+  readonly extensions = ['.rs'];
+  protected readonly wasmName = 'tree-sitter-rust.wasm';
+
+  protected extractFromTree(
+    tree: TSTree,
+    relPath: string,
+    _source: string,
+    includeMethodCalls: boolean,
+  ): ExtractedSymbols {
+    const classMap = new Map<string, ClassInfo>();
+    const interfaces: InterfaceInfo[] = [];
+    const functions: FunctionInfo[] = [];
+    const methodCalls: MethodCallInfo[] = [];
+    const root = tree.rootNode;
+
+    // ── Structs ──
+    for (const node of this.findNodes(root, 'struct_item')) {
+      const name = this.fieldText(node, 'name');
+      if (!name) continue;
+      classMap.set(name, {
+        name,
+        filePath: relPath,
+        baseClass: null,
+        interfaces: [],
+        methods: [],
+        isAbstract: false,
+      });
+    }
+
+    // ── Enum items (treated as classes) ──
+    for (const node of this.findNodes(root, 'enum_item')) {
+      const name = this.fieldText(node, 'name');
+      if (!name) continue;
+      classMap.set(name, {
+        name,
+        filePath: relPath,
+        baseClass: null,
+        interfaces: [],
+        methods: [],
+        isAbstract: false,
+      });
+    }
+
+    // ── Traits → InterfaceInfo ──
+    for (const node of this.findNodes(root, 'trait_item')) {
+      const name = this.fieldText(node, 'name');
+      if (!name) continue;
+
+      const methods: Array<{ name: string; returnType: string }> = [];
+      const body = this.findChild(node, 'declaration_list');
+      if (body) {
+        for (const fn of this.findChildren(body, 'function_signature_item')) {
+          const fnName = this.fieldText(fn, 'name');
+          if (fnName) {
+            methods.push({ name: fnName, returnType: this.getReturnType(fn) });
+          }
+        }
+        for (const fn of this.findChildren(body, 'function_item')) {
+          const fnName = this.fieldText(fn, 'name');
+          if (fnName) {
+            methods.push({ name: fnName, returnType: this.getReturnType(fn) });
+          }
+        }
+      }
+
+      // Trait bounds (supertraits)
+      const bounds = this.findChild(node, 'trait_bounds');
+      const extendsArr: string[] = [];
+      if (bounds) {
+        for (const bound of this.findNodes(bounds, 'type_identifier')) {
+          extendsArr.push(bound.text);
+        }
+      }
+
+      interfaces.push({ name, filePath: relPath, extends: extendsArr, methods });
+    }
+
+    // ── impl blocks ──
+    for (const node of this.findNodes(root, 'impl_item')) {
+      const traitNode = node.childForFieldName('trait');
+      const typeNode = node.childForFieldName('type');
+      const structName = typeNode?.text?.replace(/^\*/, '') ?? null;
+      const traitName = traitNode?.text ?? null;
+
+      // Get methods from impl body
+      const body = this.findChild(node, 'declaration_list');
+      const implMethods: ClassInfo['methods'] = [];
+      if (body) {
+        for (const fn of this.findChildren(body, 'function_item')) {
+          const fnName = this.fieldText(fn, 'name');
+          if (!fnName) continue;
+          implMethods.push({
+            name: fnName,
+            returnType: this.getReturnType(fn),
+            parameters: this.extractParams(fn),
+          });
+
+          if (includeMethodCalls && structName) {
+            const callerName = `${structName}.${fnName}`;
+            for (const call of this.findNodes(fn, 'call_expression')) {
+              const fnExpr = call.childForFieldName('function');
+              if (fnExpr && fnExpr.type === 'field_expression') {
+                const field = fnExpr.childForFieldName('field');
+                const value = fnExpr.childForFieldName('value');
+                if (field && value) {
+                  methodCalls.push({
+                    caller: callerName,
+                    callee: `${value.text}.${field.text}`,
+                  });
+                }
+              }
+            }
+          }
+        }
+      }
+
+      if (structName) {
+        let cls = classMap.get(structName);
+        if (!cls) {
+          cls = {
+            name: structName,
+            filePath: relPath,
+            baseClass: null,
+            interfaces: [],
+            methods: [],
+            isAbstract: false,
+          };
+          classMap.set(structName, cls);
+        }
+        cls.methods.push(...implMethods);
+        if (traitName) {
+          cls.interfaces.push(traitName);
+        }
+      }
+    }
+
+    // ── Top-level functions ──
+    for (const node of this.findChildren(root, 'function_item')) {
+      const name = this.fieldText(node, 'name');
+      if (!name) continue;
+
+      functions.push({
+        name,
+        filePath: relPath,
+        returnType: this.getReturnType(node),
+        parameters: this.extractParams(node),
+        isExported: this.hasVisibility(node, 'pub'),
+      });
+    }
+
+    return {
+      classes: [...classMap.values()],
+      interfaces,
+      functions,
+      methodCalls,
+    };
+  }
+
+  private extractParams(fn: TSNode): Array<{ name: string; type: string }> {
+    const params: Array<{ name: string; type: string }> = [];
+    const paramList = fn.childForFieldName('parameters');
+    if (!paramList) return params;
+
+    for (const param of this.findNodes(paramList, 'parameter')) {
+      const pattern = param.childForFieldName('pattern');
+      const typeNode = param.childForFieldName('type');
+      if (pattern && pattern.text !== 'self' && pattern.text !== '&self' && pattern.text !== '&mut self') {
+        params.push({ name: pattern.text, type: typeNode?.text ?? '' });
+      }
+    }
+    return params;
+  }
+
+  private getReturnType(fn: TSNode): string {
+    const retType = fn.childForFieldName('return_type');
+    return retType ? retType.text : 'void';
+  }
+
+  private hasVisibility(node: TSNode, vis: string): boolean {
+    const visNode = this.findChild(node, 'visibility_modifier');
+    return visNode?.text?.includes(vis) ?? false;
+  }
+}

--- a/src/lib/extractors/swift.ts
+++ b/src/lib/extractors/swift.ts
@@ -1,0 +1,177 @@
+/**
+ * Swift extractor — uses Tree-sitter to extract classes, structs, protocols, and functions.
+ * Swift class/struct → ClassInfo, Swift protocol → InterfaceInfo.
+ */
+
+import { TreeSitterExtractor } from '../deep-scanner-treesitter.js';
+import type { TSNode, TSTree } from '../deep-scanner-treesitter.js';
+import type { ExtractedSymbols } from '../language-extractor.js';
+import type { ClassInfo, InterfaceInfo, FunctionInfo, MethodCallInfo } from '../deep-scanner.js';
+
+export class SwiftExtractor extends TreeSitterExtractor {
+  readonly language = 'swift';
+  readonly extensions = ['.swift'];
+  protected readonly wasmName = 'tree-sitter-swift.wasm';
+
+  protected extractFromTree(
+    tree: TSTree,
+    relPath: string,
+    _source: string,
+    includeMethodCalls: boolean,
+  ): ExtractedSymbols {
+    const classes: ClassInfo[] = [];
+    const interfaces: InterfaceInfo[] = [];
+    const functions: FunctionInfo[] = [];
+    const methodCalls: MethodCallInfo[] = [];
+    const root = tree.rootNode;
+
+    // ── Classes ──
+    for (const node of this.findNodes(root, 'class_declaration')) {
+      const info = this.extractClassLike(node, relPath, includeMethodCalls, methodCalls);
+      if (info) classes.push(info);
+    }
+
+    // ── Structs → ClassInfo ──
+    for (const node of this.findNodes(root, 'struct_declaration')) {
+      const info = this.extractClassLike(node, relPath, includeMethodCalls, methodCalls);
+      if (info) classes.push(info);
+    }
+
+    // ── Protocols → InterfaceInfo ──
+    for (const node of this.findNodes(root, 'protocol_declaration')) {
+      const name = this.fieldText(node, 'name');
+      if (!name) continue;
+
+      const inheritances = this.getInheritances(node);
+      const methods: Array<{ name: string; returnType: string }> = [];
+
+      const body = this.findChild(node, 'protocol_body');
+      if (body) {
+        for (const fn of this.findNodes(body, 'function_declaration')) {
+          const fnName = this.fieldText(fn, 'name');
+          if (fnName) {
+            methods.push({ name: fnName, returnType: this.getReturnType(fn) });
+          }
+        }
+      }
+
+      interfaces.push({ name, filePath: relPath, extends: inheritances, methods });
+    }
+
+    // ── Top-level functions ──
+    for (const node of this.findChildren(root, 'function_declaration')) {
+      const name = this.fieldText(node, 'name');
+      if (!name) continue;
+
+      functions.push({
+        name,
+        filePath: relPath,
+        returnType: this.getReturnType(node),
+        parameters: this.extractParams(node),
+        isExported: !name.startsWith('_'),
+      });
+    }
+
+    return { classes, interfaces, functions, methodCalls };
+  }
+
+  private extractClassLike(
+    node: TSNode,
+    relPath: string,
+    includeMethodCalls: boolean,
+    methodCalls: MethodCallInfo[],
+  ): ClassInfo | null {
+    const name = this.fieldText(node, 'name');
+    if (!name) return null;
+
+    const inheritances = this.getInheritances(node);
+    // First inheritance is typically the superclass for classes
+    const baseClass = node.type === 'class_declaration' && inheritances.length > 0
+      ? inheritances[0]
+      : null;
+    const protocols = baseClass ? inheritances.slice(1) : inheritances;
+
+    const methods: ClassInfo['methods'] = [];
+    const body = this.findChild(node, 'class_body') ?? this.findChild(node, 'struct_body');
+    if (body) {
+      for (const fn of this.findNodes(body, 'function_declaration')) {
+        const fnName = this.fieldText(fn, 'name');
+        if (!fnName) continue;
+
+        methods.push({
+          name: fnName,
+          returnType: this.getReturnType(fn),
+          parameters: this.extractParams(fn),
+        });
+
+        if (includeMethodCalls) {
+          const callerName = `${name}.${fnName}`;
+          for (const call of this.findNodes(fn, 'call_expression')) {
+            const fnExpr = call.childForFieldName('function');
+            if (fnExpr && fnExpr.type === 'navigation_expression') {
+              const target = fnExpr.childForFieldName('target');
+              const suffix = fnExpr.childForFieldName('suffix');
+              if (target && suffix) {
+                methodCalls.push({
+                  caller: callerName,
+                  callee: `${target.text}.${suffix.text}`,
+                });
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return {
+      name,
+      filePath: relPath,
+      baseClass,
+      interfaces: protocols,
+      methods,
+      isAbstract: false,
+    };
+  }
+
+  private getInheritances(node: TSNode): string[] {
+    const result: string[] = [];
+    const inheritanceClause = this.findChild(node, 'type_inheritance_clause');
+    if (!inheritanceClause) return result;
+
+    for (const typeId of this.findNodes(inheritanceClause, 'user_type')) {
+      result.push(typeId.text);
+    }
+    if (result.length === 0) {
+      // Fallback: try type_identifier
+      for (const typeId of this.findNodes(inheritanceClause, 'type_identifier')) {
+        result.push(typeId.text);
+      }
+    }
+    return result;
+  }
+
+  private extractParams(fn: TSNode): Array<{ name: string; type: string }> {
+    const params: Array<{ name: string; type: string }> = [];
+    for (const param of this.findNodes(fn, 'parameter')) {
+      const name = param.childForFieldName('external_name')?.text
+        ?? param.childForFieldName('name')?.text
+        ?? '';
+      const typeNode = param.childForFieldName('type');
+      if (name !== '_') {
+        params.push({ name, type: typeNode?.text ?? '' });
+      }
+    }
+    return params;
+  }
+
+  private getReturnType(fn: TSNode): string {
+    // Look for return type annotation after '->'
+    for (let i = 0; i < fn.childCount; i++) {
+      const child = fn.child(i)!;
+      if (child.type === 'type_annotation' || child.type === 'function_type') {
+        return child.text.replace(/^->\s*/, '');
+      }
+    }
+    return 'Void';
+  }
+}

--- a/src/lib/language-extractor.ts
+++ b/src/lib/language-extractor.ts
@@ -1,0 +1,36 @@
+/**
+ * Language extractor interface — common contract for all language-specific
+ * symbol extractors (ts-morph, tree-sitter, etc.).
+ */
+
+import type { ClassInfo, InterfaceInfo, FunctionInfo, MethodCallInfo } from './deep-scanner.js';
+
+export interface ExtractedSymbols {
+  classes: ClassInfo[];
+  interfaces: InterfaceInfo[];
+  functions: FunctionInfo[];
+  methodCalls: MethodCallInfo[];
+}
+
+export interface LanguageExtractor {
+  /** Language identifier, e.g. 'typescript', 'python', 'go' */
+  readonly language: string;
+
+  /** File extensions handled by this extractor, e.g. ['.ts', '.tsx'] */
+  readonly extensions: string[];
+
+  /** Check whether the extractor's dependencies are available at runtime. */
+  isAvailable(): Promise<boolean>;
+
+  /**
+   * Extract symbols from the given source files.
+   * @param filePaths  Absolute paths to source files for this language.
+   * @param rootDir    Project root directory (for computing relative paths).
+   * @param options    Shared scan options.
+   */
+  extract(
+    filePaths: string[],
+    rootDir: string,
+    options: { maxSymbols: number; timeoutMs: number; includeMethodCalls: boolean },
+  ): Promise<ExtractedSymbols & { warnings: string[]; capped: boolean; fatal?: string }>;
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -387,6 +387,7 @@ async function handleContextScan(args: Record<string, unknown>): Promise<unknown
       maxSymbols: args.maxSymbols as number | undefined,
       timeoutMs: args.timeoutMs as number | undefined,
       includeMethodCalls: args.includeMethodCalls as boolean | undefined,
+      languages: args.languages as string[] | undefined,
     });
 
     if (!scanResult.deepScanAvailable) {
@@ -1064,7 +1065,7 @@ export async function startMcpServer(): Promise<void> {
       },
       {
         name: 'opentology_context_scan',
-        description: 'Scan the current project codebase. depth="module" (default) returns a structured snapshot with file-level dependency graph. depth="symbol" (experimental) uses ts-morph to extract class/interface/method-level dependencies and auto-pushes OTX triples to the context graph.',
+        description: 'Scan the current project codebase. depth="module" (default) returns a structured snapshot with file-level dependency graph. depth="symbol" (experimental) extracts class/interface/method-level dependencies and auto-pushes OTX triples to the context graph. Supports TypeScript (ts-morph), Python, Go, Rust, Java, Swift (Tree-sitter).',
         inputSchema: {
           type: 'object' as const,
           properties: {
@@ -1092,6 +1093,11 @@ export async function startMcpServer(): Promise<void> {
             includeMethodCalls: {
               type: 'boolean',
               description: 'Extract method call relationships when depth="symbol" (default: false, expensive).',
+            },
+            languages: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Languages to scan when depth="symbol" (e.g. ["typescript", "python", "go", "rust", "java", "swift"]). Auto-detects if omitted.',
             },
           },
         },


### PR DESCRIPTION
## Summary

- **LanguageExtractor 인터페이스 도입**: 언어별 심볼 추출기를 플러그인 방식으로 등록
- **TypeScriptExtractor 분리**: 기존 ts-morph 로직을 독립 모듈로 추출, deep-scanner.ts를 언어 무관 오케스트레이터로 리팩터
- **Tree-sitter 기반 5개 언어 추가**: Python, Go, Rust, Java, Swift 각각의 심볼 추출기 구현 (web-tree-sitter + tree-sitter-wasms)
- **MCP `languages` 파라미터 추가**: `opentology_context_scan`에서 스캔 대상 언어를 명시적으로 지정 가능
- **README 업데이트**: 딥스캔 섹션 추가, MCP 도구 수 11→18 정정, 누락된 7개 도구 테이블 추가

### 아키텍처

```
deepScan(rootDir, options)           ← 언어 감지 + 오케스트레이터
  ├─ TypeScriptExtractor (ts-morph)
  ├─ PythonExtractor (tree-sitter)
  ├─ GoExtractor (tree-sitter)
  ├─ RustExtractor (tree-sitter)
  ├─ JavaExtractor (tree-sitter)
  └─ SwiftExtractor (tree-sitter)
       ↓
  DeepScanResult (기존 타입 그대로)
       ↓
  pushSymbolTriples() (변경 없음)
```

Closes #19

## Test plan

- [x] `npm run build` 성공
- [x] `npm test` 97개 테스트 전부 통과
- [ ] Python/Go/Rust/Java/Swift 프로젝트에서 `depth="symbol"` 스캔 테스트 (web-tree-sitter + tree-sitter-wasms 설치 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)