### PR TITLE
feat: add graph visualization with Mermaid/DOT output

### DIFF
--- a/src/commands/viz.ts
+++ b/src/commands/viz.ts
@@ -1,0 +1,60 @@
+import { Command } from 'commander';
+import { loadConfig, resolveGraphUri } from '../lib/config.js';
+import { createReadyAdapter } from '../lib/store-factory.js';
+import { fromSchemaData, toMermaid, toDot } from '../lib/visualizer.js';
+import { writeFileSync } from 'fs';
+
+export function registerViz(program: Command): void {
+  const viz = program
+    .command('viz')
+    .description('Visualize graph data as Mermaid or DOT diagrams');
+
+  viz
+    .command('schema')
+    .description('Visualize the ontology schema (classes, properties, relationships)')
+    .option('--format <type>', 'Output format: mermaid, dot', 'mermaid')
+    .option('--output <file>', 'Write output to file instead of stdout')
+    .option('--graph <name>', 'Target a specific named graph')
+    .action(async (options: { format?: string; output?: string; graph?: string }) => {
+      let config;
+      try {
+        config = loadConfig();
+      } catch (err) {
+        console.error(`Error: ${(err as Error).message}`);
+        process.exit(1);
+      }
+
+      const graphUri = options.graph ? resolveGraphUri(config, options.graph) : config.graphUri;
+      const format = options.format || 'mermaid';
+
+      if (format !== 'mermaid' && format !== 'dot') {
+        console.error(`Error: unsupported format "${format}". Use "mermaid" or "dot".`);
+        process.exit(1);
+      }
+
+      try {
+        const adapter = await createReadyAdapter(config);
+        const overview = await adapter.getSchemaOverview(graphUri);
+        const relations = await adapter.getSchemaRelations(graphUri);
+        const visGraph = fromSchemaData(overview, relations);
+
+        const output = format === 'dot' ? toDot(visGraph) : toMermaid(visGraph);
+
+        if (options.output) {
+          writeFileSync(options.output, output, 'utf-8');
+          console.log(`Written to ${options.output}`);
+        } else {
+          console.log(output);
+        }
+      } catch (err) {
+        const message = (err as Error).message;
+        console.error(`Error: ${message}`);
+        if (message.includes('fetch failed') || message.includes('ECONNREFUSED')) {
+          console.error(
+            `Cannot connect to triplestore at ${config.endpoint ?? 'unknown'}. Is it running?`,
+          );
+        }
+        process.exit(1);
+      }
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { registerGraph } from './commands/graph.js';
 import { registerInfer } from './commands/infer.js';
 import { registerPrefix } from './commands/prefix.js';
 import { registerContext } from './commands/context.js';
+import { registerViz } from './commands/viz.js';
 
 const program = new Command();
 program
@@ -37,5 +38,6 @@ registerGraph(program);
 registerInfer(program);
 registerPrefix(program);
 registerContext(program);
+registerViz(program);
 
 program.parse(process.argv);

--- a/src/lib/embedded-adapter.ts
+++ b/src/lib/embedded-adapter.ts
@@ -296,4 +296,33 @@ export class EmbeddedAdapter implements StoreAdapter {
 
     return { classUri, instanceCount, properties, sampleTriples };
   }
+
+  async getSchemaRelations(graphUri: string): Promise<import('./store-adapter.js').SchemaRelations> {
+    const subClassResults = await this.sparqlQuery(
+      `SELECT DISTINCT ?child ?parent WHERE { GRAPH <${graphUri}> { ?child <http://www.w3.org/2000/01/rdf-schema#subClassOf> ?parent } }`,
+    );
+    const subClassOf = subClassResults.results.bindings
+      .filter((b) => b['child'] && b['parent'])
+      .map((b) => ({ child: b['child']!.value, parent: b['parent']!.value }));
+
+    const domainRangeResults = await this.sparqlQuery(
+      `SELECT DISTINCT ?prop ?domain ?range WHERE {
+        GRAPH <${graphUri}> {
+          ?prop a ?type .
+          OPTIONAL { ?prop <http://www.w3.org/2000/01/rdf-schema#domain> ?domain }
+          OPTIONAL { ?prop <http://www.w3.org/2000/01/rdf-schema#range> ?range }
+          FILTER(?type IN (<http://www.w3.org/1999/02/22-rdf-syntax-ns#Property>, <http://www.w3.org/2002/07/owl#ObjectProperty>, <http://www.w3.org/2002/07/owl#DatatypeProperty>))
+        }
+      }`,
+    );
+    const domainRange = domainRangeResults.results.bindings
+      .filter((b) => b['prop'] && (b['domain'] || b['range']))
+      .map((b) => ({
+        property: b['prop']!.value,
+        domain: b['domain']?.value,
+        range: b['range']?.value,
+      }));
+
+    return { subClassOf, domainRange };
+  }
 }

--- a/src/lib/http-adapter.ts
+++ b/src/lib/http-adapter.ts
@@ -262,4 +262,33 @@ export class HttpAdapter implements StoreAdapter {
 
     return { classUri, instanceCount, properties, sampleTriples };
   }
+
+  async getSchemaRelations(graphUri: string): Promise<import('./store-adapter.js').SchemaRelations> {
+    const subClassResults = await this.sparqlQuery(
+      `SELECT DISTINCT ?child ?parent WHERE { GRAPH <${graphUri}> { ?child <http://www.w3.org/2000/01/rdf-schema#subClassOf> ?parent } }`,
+    );
+    const subClassOf = subClassResults.results.bindings
+      .filter((b) => b['child'] && b['parent'])
+      .map((b) => ({ child: b['child']!.value, parent: b['parent']!.value }));
+
+    const domainRangeResults = await this.sparqlQuery(
+      `SELECT DISTINCT ?prop ?domain ?range WHERE {
+        GRAPH <${graphUri}> {
+          ?prop a ?type .
+          OPTIONAL { ?prop <http://www.w3.org/2000/01/rdf-schema#domain> ?domain }
+          OPTIONAL { ?prop <http://www.w3.org/2000/01/rdf-schema#range> ?range }
+          FILTER(?type IN (<http://www.w3.org/1999/02/22-rdf-syntax-ns#Property>, <http://www.w3.org/2002/07/owl#ObjectProperty>, <http://www.w3.org/2002/07/owl#DatatypeProperty>))
+        }
+      }`,
+    );
+    const domainRange = domainRangeResults.results.bindings
+      .filter((b) => b['prop'] && (b['domain'] || b['range']))
+      .map((b) => ({
+        property: b['prop']!.value,
+        domain: b['domain']?.value,
+        range: b['range']?.value,
+      }));
+
+    return { subClassOf, domainRange };
+  }
 }

--- a/src/lib/store-adapter.ts
+++ b/src/lib/store-adapter.ts
@@ -5,6 +5,11 @@ export interface SparqlResults {
   };
 }
 
+export interface SchemaRelations {
+  subClassOf: Array<{ child: string; parent: string }>;
+  domainRange: Array<{ property: string; domain?: string; range?: string }>;
+}
+
 export interface StoreAdapter {
   // Core SPARQL operations
   sparqlQuery(query: string): Promise<SparqlResults>;
@@ -41,4 +46,7 @@ export interface StoreAdapter {
     properties: Array<{ property: string; count: number }>;
     sampleTriples: Array<{ s: string; p: string; o: string }>;
   }>;
+
+  // Schema relationships for visualization
+  getSchemaRelations(graphUri: string): Promise<SchemaRelations>;
 }

--- a/src/lib/visualizer.ts
+++ b/src/lib/visualizer.ts
@@ -1,0 +1,189 @@
+import { WELL_KNOWN_PREFIXES } from './sparql-utils.js';
+import type { SchemaRelations } from './store-adapter.js';
+
+export interface VisNode {
+  id: string;
+  label: string;
+  type?: 'class' | 'property' | 'instance' | 'bnode';
+}
+
+export interface VisEdge {
+  source: string;
+  target: string;
+  label: string;
+}
+
+export interface VisGraph {
+  nodes: VisNode[];
+  edges: VisEdge[];
+  prefixes: Record<string, string>;
+}
+
+export function shortenUri(uri: string, prefixes: Record<string, string>): string {
+  // Check provided prefixes first (prefix -> namespace mapping)
+  for (const [prefix, ns] of Object.entries(prefixes)) {
+    if (uri.startsWith(ns)) {
+      return `${prefix}:${uri.slice(ns.length)}`;
+    }
+  }
+  // Check well-known prefixes (namespace -> prefix mapping)
+  for (const [ns, prefix] of Object.entries(WELL_KNOWN_PREFIXES)) {
+    if (uri.startsWith(ns)) {
+      return `${prefix}:${uri.slice(ns.length)}`;
+    }
+  }
+  // Fallback: extract local name after # or last /
+  const hashIdx = uri.lastIndexOf('#');
+  if (hashIdx !== -1) return uri.slice(hashIdx + 1);
+  const slashIdx = uri.lastIndexOf('/');
+  if (slashIdx !== -1) return uri.slice(slashIdx + 1);
+  return uri;
+}
+
+function makeClassNode(uri: string, prefixes: Record<string, string>): VisNode {
+  const isBnode = uri.startsWith('_:');
+  return { id: uri, label: isBnode ? '[]' : shortenUri(uri, prefixes), type: isBnode ? 'bnode' : 'class' };
+}
+
+function ensureNode(nodeMap: Map<string, VisNode>, uri: string, prefixes: Record<string, string>, type: VisNode['type'] = 'class'): void {
+  if (!nodeMap.has(uri)) {
+    nodeMap.set(uri, type === 'property'
+      ? { id: uri, label: shortenUri(uri, prefixes), type: 'property' }
+      : makeClassNode(uri, prefixes));
+  }
+}
+
+export function fromSchemaData(
+  overview: { prefixes: Record<string, string>; classes: string[]; properties: string[] },
+  relations: SchemaRelations,
+): VisGraph {
+  const prefixes = { ...overview.prefixes };
+  const nodeMap = new Map<string, VisNode>();
+  const edges: VisEdge[] = [];
+
+  for (const cls of overview.classes) {
+    ensureNode(nodeMap, cls, prefixes);
+  }
+
+  for (const { child, parent } of relations.subClassOf) {
+    ensureNode(nodeMap, child, prefixes);
+    ensureNode(nodeMap, parent, prefixes);
+    edges.push({ source: child, target: parent, label: 'subClassOf' });
+  }
+
+  for (const { property, domain, range } of relations.domainRange) {
+    ensureNode(nodeMap, property, prefixes, 'property');
+    if (domain) {
+      ensureNode(nodeMap, domain, prefixes);
+      edges.push({ source: property, target: domain, label: 'domain' });
+    }
+    if (range) {
+      ensureNode(nodeMap, range, prefixes);
+      edges.push({ source: property, target: range, label: 'range' });
+    }
+  }
+
+  return {
+    nodes: [...nodeMap.values()],
+    edges,
+    prefixes,
+  };
+}
+
+function mermaidId(uri: string): string {
+  return uri.replace(/[^a-zA-Z0-9_]/g, '_');
+}
+
+const MERMAID_NODE_LIMIT = 150;
+const DOT_NODE_LIMIT = 500;
+
+export function toMermaid(graph: VisGraph): string {
+  if (graph.nodes.length === 0) {
+    return 'graph TD\n  %% Empty graph';
+  }
+
+  const lines: string[] = ['graph TD'];
+  const truncated = graph.nodes.length > MERMAID_NODE_LIMIT;
+  const nodes = truncated ? graph.nodes.slice(0, MERMAID_NODE_LIMIT) : graph.nodes;
+  const nodeIds = new Set(nodes.map((n) => n.id));
+
+  if (truncated) {
+    lines.push(`  %% WARNING: Truncated to ${MERMAID_NODE_LIMIT} of ${graph.nodes.length} nodes`);
+  }
+
+  // Node definitions with shapes based on type
+  for (const node of nodes) {
+    const id = mermaidId(node.id);
+    const label = node.label.replace(/"/g, '#quot;');
+    switch (node.type) {
+      case 'class':
+        lines.push(`  ${id}["${label}"]`);
+        break;
+      case 'property':
+        lines.push(`  ${id}(["${label}"])`);
+        break;
+      case 'bnode':
+        lines.push(`  ${id}{"${label}"}`);
+        break;
+      default:
+        lines.push(`  ${id}["${label}"]`);
+    }
+  }
+
+  // Edges (only for nodes in the truncated set)
+  for (const edge of graph.edges) {
+    if (!nodeIds.has(edge.source) || !nodeIds.has(edge.target)) continue;
+    const src = mermaidId(edge.source);
+    const tgt = mermaidId(edge.target);
+    const label = edge.label.replace(/"/g, '#quot;');
+    lines.push(`  ${src} -->|"${label}"| ${tgt}`);
+  }
+
+  return lines.join('\n');
+}
+
+export function toDot(graph: VisGraph): string {
+  if (graph.nodes.length === 0) {
+    return 'digraph G {\n  // Empty graph\n}';
+  }
+
+  const lines: string[] = ['digraph G {', '  rankdir=TB;', '  node [fontname="Helvetica"];'];
+  const truncated = graph.nodes.length > DOT_NODE_LIMIT;
+  const nodes = truncated ? graph.nodes.slice(0, DOT_NODE_LIMIT) : graph.nodes;
+  const nodeIds = new Set(nodes.map((n) => n.id));
+
+  if (truncated) {
+    lines.push(`  // WARNING: Truncated to ${DOT_NODE_LIMIT} of ${graph.nodes.length} nodes`);
+  }
+
+  // Node definitions with shapes based on type
+  for (const node of nodes) {
+    const id = mermaidId(node.id); // reuse sanitizer
+    const label = node.label.replace(/"/g, '\\"');
+    switch (node.type) {
+      case 'class':
+        lines.push(`  ${id} [label="${label}" shape=box];`);
+        break;
+      case 'property':
+        lines.push(`  ${id} [label="${label}" shape=ellipse];`);
+        break;
+      case 'bnode':
+        lines.push(`  ${id} [label="${label}" shape=diamond];`);
+        break;
+      default:
+        lines.push(`  ${id} [label="${label}" shape=box];`);
+    }
+  }
+
+  // Edges
+  for (const edge of graph.edges) {
+    if (!nodeIds.has(edge.source) || !nodeIds.has(edge.target)) continue;
+    const src = mermaidId(edge.source);
+    const tgt = mermaidId(edge.target);
+    const label = edge.label.replace(/"/g, '\\"');
+    lines.push(`  ${src} -> ${tgt} [label="${label}"];`);
+  }
+
+  lines.push('}');
+  return lines.join('\n');
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -18,6 +18,7 @@ import { hasGraphScope, autoScopeQuery, getInferenceGraphUri } from '../lib/spar
 import { validateTurtle } from '../lib/validator.js';
 import { discoverShapes, validateWithShacl, hasShapes } from '../lib/shacl.js';
 import { materializeInferences, clearInferences } from '../lib/reasoner.js';
+import { fromSchemaData, toMermaid, toDot } from '../lib/visualizer.js';
 import type { InferenceResult } from '../lib/reasoner.js';
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -666,6 +667,30 @@ async function handleContextStatus(): Promise<unknown> {
   return result;
 }
 
+async function handleVisualize(args: Record<string, unknown>): Promise<unknown> {
+  const { config, graphUri } = resolveConfig({
+    graphUri: args.graphUri as string | undefined,
+    graph: args.graph as string | undefined,
+  });
+
+  const target = (args.target as string) || 'schema';
+  if (target !== 'schema') {
+    throw new Error(`Unsupported target "${target}". Currently only "schema" is supported.`);
+  }
+
+  const format = (args.format as string) || 'mermaid';
+  if (format !== 'mermaid' && format !== 'dot') {
+    throw new Error(`Unsupported format "${format}". Use "mermaid" or "dot".`);
+  }
+
+  const adapter = await createReadyAdapter(config);
+  const overview = await adapter.getSchemaOverview(graphUri);
+  const relations = await adapter.getSchemaRelations(graphUri);
+  const visGraph = fromSchemaData(overview, relations);
+
+  return format === 'dot' ? toDot(visGraph) : toMermaid(visGraph);
+}
+
 export async function startMcpServer(): Promise<void> {
   const server = new Server(
     { name: 'opentology', version: '0.1.0' },
@@ -1102,6 +1127,33 @@ export async function startMcpServer(): Promise<void> {
           },
         },
       },
+      {
+        name: 'opentology_visualize',
+        description: 'Generate a visual diagram of the graph schema. Returns Mermaid or DOT text showing classes, properties, and their relationships (subClassOf, domain/range).',
+        inputSchema: {
+          type: 'object' as const,
+          properties: {
+            target: {
+              type: 'string',
+              enum: ['schema'],
+              description: 'What to visualize. Currently only "schema" is supported.',
+            },
+            format: {
+              type: 'string',
+              enum: ['mermaid', 'dot'],
+              description: 'Output format: mermaid (default) or dot (Graphviz).',
+            },
+            graph: {
+              type: 'string',
+              description: 'Logical graph name (as created by opentology_graph_create). Resolves to a graph URI via config.',
+            },
+            graphUri: {
+              type: 'string',
+              description: 'Named graph URI (uses config default if omitted)',
+            },
+          },
+        },
+      },
     ],
   }));
 
@@ -1163,6 +1215,9 @@ export async function startMcpServer(): Promise<void> {
           break;
         case 'opentology_context_status':
           result = await handleContextStatus();
+          break;
+        case 'opentology_visualize':
+          result = await handleVisualize(args as Record<string, unknown>);
           break;
         default:
           throw new Error(`Unknown tool: ${name}`);

--- a/tests/unit/visualizer.test.ts
+++ b/tests/unit/visualizer.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect } from 'vitest';
+import {
+  shortenUri,
+  fromSchemaData,
+  toMermaid,
+  toDot,
+  type VisGraph,
+  type VisNode,
+} from '../../src/lib/visualizer.js';
+import type { SchemaRelations } from '../../src/lib/store-adapter.js';
+
+// ── shortenUri ───────────────────────────────────────────────────────
+
+describe('shortenUri', () => {
+  it('shortens well-known prefixes', () => {
+    expect(shortenUri('http://www.w3.org/2000/01/rdf-schema#Class', {})).toBe('rdfs:Class');
+    expect(shortenUri('http://www.w3.org/1999/02/22-rdf-syntax-ns#type', {})).toBe('rdf:type');
+    expect(shortenUri('http://schema.org/Person', {})).toBe('schema:Person');
+  });
+
+  it('shortens with provided prefixes (priority over well-known)', () => {
+    const prefixes = { ex: 'http://example.org/' };
+    expect(shortenUri('http://example.org/Foo', prefixes)).toBe('ex:Foo');
+  });
+
+  it('falls back to local name after # for unknown URIs', () => {
+    expect(shortenUri('http://unknown.org/ontology#MyClass', {})).toBe('MyClass');
+  });
+
+  it('falls back to local name after / for unknown URIs', () => {
+    expect(shortenUri('http://unknown.org/path/MyClass', {})).toBe('MyClass');
+  });
+
+  it('returns full URI if no # or / separator found', () => {
+    expect(shortenUri('urn:something', {})).toBe('urn:something');
+  });
+});
+
+// ── fromSchemaData ───────────────────────────────────────────────────
+
+describe('fromSchemaData', () => {
+  it('produces correct nodes for classes', () => {
+    const overview = {
+      prefixes: { ex: 'http://example.org/' },
+      classes: ['http://example.org/Person', 'http://example.org/Animal'],
+      properties: [],
+    };
+    const relations: SchemaRelations = { subClassOf: [], domainRange: [] };
+
+    const graph = fromSchemaData(overview, relations);
+    expect(graph.nodes).toHaveLength(2);
+    expect(graph.nodes[0]).toEqual({
+      id: 'http://example.org/Person',
+      label: 'ex:Person',
+      type: 'class',
+    });
+    expect(graph.nodes[1]).toEqual({
+      id: 'http://example.org/Animal',
+      label: 'ex:Animal',
+      type: 'class',
+    });
+  });
+
+  it('produces correct edges for subClassOf', () => {
+    const overview = {
+      prefixes: {},
+      classes: ['http://example.org/Dog', 'http://example.org/Animal'],
+      properties: [],
+    };
+    const relations: SchemaRelations = {
+      subClassOf: [{ child: 'http://example.org/Dog', parent: 'http://example.org/Animal' }],
+      domainRange: [],
+    };
+
+    const graph = fromSchemaData(overview, relations);
+    expect(graph.edges).toHaveLength(1);
+    expect(graph.edges[0]).toEqual({
+      source: 'http://example.org/Dog',
+      target: 'http://example.org/Animal',
+      label: 'subClassOf',
+    });
+  });
+
+  it('produces correct edges for domainRange', () => {
+    const overview = {
+      prefixes: {},
+      classes: ['http://example.org/Person'],
+      properties: ['http://example.org/name'],
+    };
+    const relations: SchemaRelations = {
+      subClassOf: [],
+      domainRange: [
+        {
+          property: 'http://example.org/name',
+          domain: 'http://example.org/Person',
+          range: 'http://www.w3.org/2001/XMLSchema#string',
+        },
+      ],
+    };
+
+    const graph = fromSchemaData(overview, relations);
+    const domainEdge = graph.edges.find((e) => e.label === 'domain');
+    const rangeEdge = graph.edges.find((e) => e.label === 'range');
+    expect(domainEdge).toBeDefined();
+    expect(domainEdge!.source).toBe('http://example.org/name');
+    expect(domainEdge!.target).toBe('http://example.org/Person');
+    expect(rangeEdge).toBeDefined();
+    expect(rangeEdge!.target).toBe('http://www.w3.org/2001/XMLSchema#string');
+  });
+
+  it('returns empty VisGraph for empty input', () => {
+    const overview = { prefixes: {}, classes: [], properties: [] };
+    const relations: SchemaRelations = { subClassOf: [], domainRange: [] };
+
+    const graph = fromSchemaData(overview, relations);
+    expect(graph.nodes).toHaveLength(0);
+    expect(graph.edges).toHaveLength(0);
+  });
+
+  it('handles blank nodes with bnode type', () => {
+    const overview = {
+      prefixes: {},
+      classes: ['_:b0'],
+      properties: [],
+    };
+    const relations: SchemaRelations = { subClassOf: [], domainRange: [] };
+
+    const graph = fromSchemaData(overview, relations);
+    expect(graph.nodes[0].type).toBe('bnode');
+  });
+
+  it('creates property nodes from domainRange', () => {
+    const overview = { prefixes: {}, classes: [], properties: [] };
+    const relations: SchemaRelations = {
+      subClassOf: [],
+      domainRange: [{ property: 'http://example.org/knows', domain: 'http://example.org/Person' }],
+    };
+
+    const graph = fromSchemaData(overview, relations);
+    const propNode = graph.nodes.find((n) => n.id === 'http://example.org/knows');
+    expect(propNode).toBeDefined();
+    expect(propNode!.type).toBe('property');
+  });
+});
+
+// ── toMermaid ────────────────────────────────────────────────────────
+
+describe('toMermaid', () => {
+  it('produces valid Mermaid syntax with graph TD header', () => {
+    const graph: VisGraph = {
+      nodes: [
+        { id: 'http://ex.org/A', label: 'A', type: 'class' },
+        { id: 'http://ex.org/B', label: 'B', type: 'class' },
+      ],
+      edges: [{ source: 'http://ex.org/A', target: 'http://ex.org/B', label: 'subClassOf' }],
+      prefixes: {},
+    };
+
+    const result = toMermaid(graph);
+    expect(result).toContain('graph TD');
+    expect(result).toContain('http___ex_org_A["A"]');
+    expect(result).toContain('http___ex_org_B["B"]');
+    expect(result).toContain('-->|"subClassOf"|');
+  });
+
+  it('produces empty diagram for empty graph', () => {
+    const graph: VisGraph = { nodes: [], edges: [], prefixes: {} };
+    const result = toMermaid(graph);
+    expect(result).toContain('graph TD');
+    expect(result).toContain('Empty graph');
+  });
+
+  it('uses different shapes for node types', () => {
+    const graph: VisGraph = {
+      nodes: [
+        { id: 'cls', label: 'Cls', type: 'class' },
+        { id: 'prop', label: 'Prop', type: 'property' },
+        { id: 'bn', label: '[]', type: 'bnode' },
+      ],
+      edges: [],
+      prefixes: {},
+    };
+
+    const result = toMermaid(graph);
+    expect(result).toContain('cls["Cls"]');       // box for class
+    expect(result).toContain('prop(["Prop"])');    // stadium for property
+    expect(result).toContain('bn{"[]"}');          // rhombus for bnode
+  });
+
+  it('truncates at 150 nodes with warning', () => {
+    const nodes: VisNode[] = Array.from({ length: 200 }, (_, i) => ({
+      id: `n${i}`,
+      label: `Node${i}`,
+      type: 'class' as const,
+    }));
+    const graph: VisGraph = { nodes, edges: [], prefixes: {} };
+
+    const result = toMermaid(graph);
+    expect(result).toContain('WARNING: Truncated to 150 of 200 nodes');
+    // Should only have 150 node definitions (+ header + warning = 152 lines)
+    const nodeLines = result.split('\n').filter((l) => l.match(/^\s+n\d+\[/));
+    expect(nodeLines).toHaveLength(150);
+  });
+});
+
+// ── toDot ────────────────────────────────────────────────────────────
+
+describe('toDot', () => {
+  it('produces valid DOT syntax with digraph header', () => {
+    const graph: VisGraph = {
+      nodes: [
+        { id: 'http://ex.org/A', label: 'A', type: 'class' },
+        { id: 'http://ex.org/B', label: 'B', type: 'class' },
+      ],
+      edges: [{ source: 'http://ex.org/A', target: 'http://ex.org/B', label: 'subClassOf' }],
+      prefixes: {},
+    };
+
+    const result = toDot(graph);
+    expect(result).toContain('digraph G {');
+    expect(result).toContain('shape=box');
+    expect(result).toContain('label="subClassOf"');
+    expect(result).toContain('}');
+  });
+
+  it('produces empty diagram for empty graph', () => {
+    const graph: VisGraph = { nodes: [], edges: [], prefixes: {} };
+    const result = toDot(graph);
+    expect(result).toContain('digraph G {');
+    expect(result).toContain('Empty graph');
+    expect(result).toContain('}');
+  });
+
+  it('uses different shapes for node types', () => {
+    const graph: VisGraph = {
+      nodes: [
+        { id: 'cls', label: 'Cls', type: 'class' },
+        { id: 'prop', label: 'Prop', type: 'property' },
+        { id: 'bn', label: '[]', type: 'bnode' },
+      ],
+      edges: [],
+      prefixes: {},
+    };
+
+    const result = toDot(graph);
+    expect(result).toContain('shape=box');      // class
+    expect(result).toContain('shape=ellipse');  // property
+    expect(result).toContain('shape=diamond');  // bnode
+  });
+
+  it('truncates at 500 nodes with warning', () => {
+    const nodes: VisNode[] = Array.from({ length: 600 }, (_, i) => ({
+      id: `n${i}`,
+      label: `Node${i}`,
+      type: 'class' as const,
+    }));
+    const graph: VisGraph = { nodes, edges: [], prefixes: {} };
+
+    const result = toDot(graph);
+    expect(result).toContain('WARNING: Truncated to 500 of 600 nodes');
+    const nodeLines = result.split('\n').filter((l) => l.match(/^\s+n\d+ \[/));
+    expect(nodeLines).toHaveLength(500);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `opentology viz schema` CLI command and `opentology_visualize` MCP tool for schema visualization
- Introduce `VisGraph` intermediate representation decoupling input parsing from output rendering
- Add `getSchemaRelations()` to StoreAdapter for rdfs:subClassOf/domain/range queries
- Implement `toMermaid()` / `toDot()` renderers with node truncation limits (150/500)

Closes #22

## Test plan

- [x] `npm run build` passes
- [x] 116 tests pass (97 existing + 19 new visualizer tests)
- [x] Architect review: APPROVE
- [x] Code review + deslop cleanup completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)