### PR TITLE
feat: v0.2.2 — auto-sync, doctor, CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          registry-url: https://registry.npmjs.org
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ graph TB
     end
 
     subgraph MCP["MCP Server"]
-        Tools[20 Tools]
+        Tools[23 Tools]
         Resource["opentology://schema"]
     end
 
@@ -97,7 +97,7 @@ graph LR
 | Docker required | No (embedded mode) | Yes | Yes |
 | RDFS reasoning | Automatic on push | Manual SPARQL CONSTRUCT | Not native |
 | SHACL validation | Built-in | Manual tooling | N/A |
-| AI integration | MCP server with 20 tools | None | Plugin ecosystem |
+| AI integration | MCP server with 23 tools | None | Plugin ecosystem |
 | Query language | SPARQL (auto-prefixed) | SPARQL (raw) | Cypher |
 | Data format | Turtle files | Turtle/N-Triples | Property graph |
 | Project scoping | Automatic named graphs | Manual | Database-level |
@@ -106,7 +106,7 @@ graph LR
 
 **Core**
 
-- 16 CLI commands covering the full RDF lifecycle
+- 18 CLI commands covering the full RDF lifecycle
 - Project-level configuration with `.opentology.json`
 - Named graph scoping -- queries are automatically scoped to your project
 - Two modes: HTTP (Oxigraph server) and embedded (WASM, zero Docker)
@@ -126,7 +126,7 @@ graph LR
 
 **AI Integration**
 
-- MCP server with 20 tools and 1 resource
+- MCP server with 23 tools and 1 resource
 - `opentology://schema` resource auto-loads ontology overview
 - Works with Claude Code, Cursor, and any MCP-compatible client
 
@@ -181,8 +181,9 @@ For embedded mode, no additional setup is needed.
 | `opentology infer` | Run RDFS materialization (`--clear` to remove inferred triples) |
 | `opentology graph` | List, create, or drop named graphs |
 | `opentology prefix` | List, add, or remove project prefixes |
-| `opentology context` | Project context management (`init`, `load`, `status`, `scan`, `graph`) |
+| `opentology context` | Project context management (`init`, `load`, `status`, `scan`, `impact`, `sync`, `graph`) |
 | `opentology viz` | Visualize ontology schema (`schema`) |
+| `opentology doctor` | Check project health (config, store, context, hooks, dependencies) |
 | `opentology mcp` | Start the MCP server |
 
 ### MCP Integration
@@ -200,7 +201,7 @@ Add to your MCP client configuration (`.mcp.json`):
 }
 ```
 
-**20 Tools:**
+**23 Tools:**
 
 | Tool | Description |
 |------|-------------|
@@ -223,7 +224,10 @@ Add to your MCP client configuration (`.mcp.json`):
 | `opentology_context_load` | Load project context |
 | `opentology_context_status` | Check context initialization status |
 | `opentology_context_scan` | Scan codebase (module or symbol-level) |
+| `opentology_context_impact` | Analyze file modification impact (dependents, dependencies, related context) |
+| `opentology_context_sync` | Auto-sync: recover missed sessions from git, rescan module graph |
 | `opentology_context_graph` | Start interactive graph visualization web UI |
+| `opentology_doctor` | Check project health (config, store, hooks, dependencies) |
 
 **1 Resource:**
 
@@ -334,8 +338,8 @@ npm install web-tree-sitter tree-sitter-wasms
 
 ### Roadmap
 
-- [x] CLI with 16 commands
-- [x] MCP server with 20 tools and 1 resource
+- [x] CLI with 18 commands
+- [x] MCP server with 23 tools and 1 resource
 - [x] Schema introspection (MCP resource + tool)
 - [x] Complete CRUD (push --replace, drop, delete)
 - [x] SHACL validation (shape constraints on push)
@@ -379,7 +383,7 @@ graph TB
     end
 
     subgraph MCP["MCP Server"]
-        Tools[20 Tools]
+        Tools[23 Tools]
         Resource["opentology://schema"]
     end
 
@@ -454,7 +458,7 @@ graph LR
 | Docker 필수 | 아니오 (임베디드 모드) | 예 | 예 |
 | RDFS 추론 | 푸시 시 자동 | SPARQL CONSTRUCT 수동 작성 | 네이티브 미지원 |
 | SHACL 검증 | 내장 | 별도 도구 필요 | 해당 없음 |
-| AI 연동 | MCP 서버 20개 도구 | 없음 | 플러그인 생태계 |
+| AI 연동 | MCP 서버 23개 도구 | 없음 | 플러그인 생태계 |
 | 쿼리 언어 | SPARQL (접두사 자동 삽입) | SPARQL (수동) | Cypher |
 | 데이터 형식 | Turtle 파일 | Turtle/N-Triples | 속성 그래프 |
 | 프로젝트 구분 | Named Graph 자동 | 수동 관리 | 데이터베이스 단위 |
@@ -463,7 +467,7 @@ graph LR
 
 **핵심**
 
-- RDF 전체 생애주기를 다루는 16개 CLI 명령어
+- RDF 전체 생애주기를 다루는 18개 CLI 명령어
 - `.opentology.json` 기반 프로젝트 설정
 - Named Graph 자동 스코핑 -- 쿼리가 프로젝트 그래프에 자동 한정
 - HTTP 모드(Oxigraph 서버)와 임베디드 모드(WASM, Docker 불필요) 지원
@@ -483,7 +487,7 @@ graph LR
 
 **AI 연동**
 
-- 20개 도구와 1개 리소스를 제공하는 MCP 서버
+- 23개 도구와 1개 리소스를 제공하는 MCP 서버
 - `opentology://schema` 리소스로 온톨로지 개요 자동 로드
 - Claude Code, Cursor 등 MCP 호환 클라이언트와 연동
 
@@ -538,8 +542,9 @@ docker run -p 7878:7878 ghcr.io/oxigraph/oxigraph \
 | `opentology infer` | RDFS 물질화 실행 (`--clear`로 추론 트리플 제거) |
 | `opentology graph` | Named Graph 목록/생성/삭제 |
 | `opentology prefix` | 프로젝트 접두사 목록/추가/제거 |
-| `opentology context` | 프로젝트 컨텍스트 관리 (`init`, `load`, `status`, `scan`, `graph`) |
+| `opentology context` | 프로젝트 컨텍스트 관리 (`init`, `load`, `status`, `scan`, `impact`, `sync`, `graph`) |
 | `opentology viz` | 온톨로지 스키마 시각화 (`schema`) |
+| `opentology doctor` | 프로젝트 건강 진단 (설정, 스토어, 컨텍스트, 훅, 의존성) |
 | `opentology mcp` | MCP 서버 시작 |
 
 ### MCP 연동
@@ -557,7 +562,7 @@ MCP 클라이언트 설정 파일(`.mcp.json`)에 추가:
 }
 ```
 
-**20개 도구:**
+**23개 도구:**
 
 | 도구 | 설명 |
 |------|------|
@@ -580,7 +585,10 @@ MCP 클라이언트 설정 파일(`.mcp.json`)에 추가:
 | `opentology_context_load` | 프로젝트 컨텍스트 로드 |
 | `opentology_context_status` | 컨텍스트 초기화 상태 확인 |
 | `opentology_context_scan` | 코드베이스 스캔 (모듈/심볼 수준) |
+| `opentology_context_impact` | 파일 수정 영향 분석 (의존 모듈, 관련 컨텍스트) |
+| `opentology_context_sync` | 자동 동기화: git에서 누락 세션 복구, 모듈 그래프 재스캔 |
 | `opentology_context_graph` | 인터랙티브 그래프 시각화 웹 UI 시작 |
+| `opentology_doctor` | 프로젝트 건강 진단 (설정, 스토어, 훅, 의존성) |
 
 **1개 리소스:**
 
@@ -691,8 +699,8 @@ npm install web-tree-sitter tree-sitter-wasms
 
 ### 로드맵
 
-- [x] 16개 CLI 명령어
-- [x] 20개 도구와 1개 리소스를 갖춘 MCP 서버
+- [x] 18개 CLI 명령어
+- [x] 23개 도구와 1개 리소스를 갖춘 MCP 서버
 - [x] 스키마 조회 (MCP 리소스 + 도구)
 - [x] 완전한 CRUD (push --replace, drop, delete)
 - [x] SHACL 검증 (푸시 시 형상 제약 자동 검증)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opentology",
-  "version": "0.1.1",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opentology",
-      "version": "0.1.1",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -4172,22 +4172,22 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -4197,9 +4197,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -6402,9 +6402,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.9",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
-      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "version": "4.12.10",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.10.tgz",
+      "integrity": "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -6955,9 +6955,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/logform": {
@@ -7350,9 +7350,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.1.tgz",
-      "integrity": "sha512-fvU78fIjZ+SBM9YwCknCvKOUKkLVqtWDVctl0s7xIqfmfb38t2TT4ZU2gHm+Z8xGwgW+QWEU3oQSAzIbo89Ggw==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentology",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "CLI-managed RDF/SPARQL infrastructure — Supabase for RDF",
   "type": "module",
   "bin": {

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -6,6 +6,7 @@ import { createInterface } from 'node:readline';
 import { loadConfig, saveConfig } from '../lib/config.js';
 import { createReadyAdapter } from '../lib/store-factory.js';
 import { startGraphServer } from '../lib/graph-server.js';
+import { syncContext } from '../lib/context-sync.js';
 import { OTX_BOOTSTRAP_TURTLE } from '../templates/otx-ontology.js';
 import { generateContextSection, updateClaudeMd } from '../templates/claude-md-context.js';
 import { generateHookScript } from '../templates/session-start-hook.js';
@@ -567,6 +568,37 @@ export function registerContext(program: Command): void {
           }
           if (dependents.length === 0 && dependencies.length === 0) {
             console.log(pc.dim('No module dependencies found. Run `opentology context scan` to populate.'));
+          }
+        }
+      } catch (err) {
+        console.error(pc.red(`Error: ${(err as Error).message}`));
+        process.exit(1);
+      }
+    });
+
+  // --- context sync ---
+  context
+    .command('sync')
+    .description('Auto-sync context graph: recover missed sessions from git log, rescan module dependencies')
+    .option('--format <type>', 'Output format: table, json', 'table')
+    .action(async (opts: { format: string }) => {
+      let config;
+      try {
+        config = loadConfig();
+      } catch {
+        console.error(pc.red('Error: No .opentology.json found. Run `opentology init` first.'));
+        process.exit(1);
+      }
+
+      try {
+        const result = await syncContext(config, process.cwd());
+
+        if (opts.format === 'json') {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(pc.bold('Context Sync'));
+          for (const action of result.actions) {
+            console.log(`  ${pc.green('•')} ${action}`);
           }
         }
       } catch (err) {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,0 +1,143 @@
+import { Command } from 'commander';
+import pc from 'picocolors';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { configExists, loadConfig } from '../lib/config.js';
+import { createReadyAdapter } from '../lib/store-factory.js';
+
+interface CheckResult {
+  name: string;
+  status: 'ok' | 'warn' | 'fail';
+  message: string;
+}
+
+export async function runDoctor(): Promise<CheckResult[]> {
+  const results: CheckResult[] = [];
+
+  // 1. Config check
+  if (!configExists()) {
+    results.push({ name: 'Config', status: 'fail', message: 'No .opentology.json found. Run `opentology init` first.' });
+    return results; // Can't proceed without config
+  }
+  const config = loadConfig();
+  results.push({ name: 'Config', status: 'ok', message: `Project: ${config.projectId} (${config.mode} mode)` });
+
+  // 2. Store connectivity
+  try {
+    const adapter = await createReadyAdapter(config);
+    const r = await adapter.sparqlQuery(`SELECT (COUNT(*) AS ?c) WHERE { GRAPH <${config.graphUri}> { ?s ?p ?o } }`);
+    const count = r.results?.bindings?.[0]?.c?.value ?? '0';
+    results.push({ name: 'Store', status: 'ok', message: `Connected — ${count} triples in default graph` });
+  } catch (err) {
+    results.push({ name: 'Store', status: 'fail', message: `Cannot connect: ${(err as Error).message}` });
+  }
+
+  // 3. Context initialization
+  const graphs = config.graphs ?? {};
+  if (graphs['context'] && graphs['sessions']) {
+    results.push({ name: 'Context', status: 'ok', message: `context: ${graphs['context']}` });
+  } else {
+    results.push({ name: 'Context', status: 'warn', message: 'Not initialized. Run `opentology context init`.' });
+  }
+
+  // 4. Hook scripts
+  const hookDir = join(process.cwd(), '.opentology', 'hooks');
+  const sessionHook = join(hookDir, 'session-start.mjs');
+  const preEditHook = join(hookDir, 'pre-edit.mjs');
+  const hooksExist = existsSync(sessionHook) && existsSync(preEditHook);
+  if (hooksExist) {
+    results.push({ name: 'Hooks', status: 'ok', message: 'session-start.mjs + pre-edit.mjs present' });
+  } else {
+    results.push({ name: 'Hooks', status: 'warn', message: 'Hook scripts missing. Run `opentology context init`.' });
+  }
+
+  // 5. Hook registration in .claude/settings.json
+  const settingsPath = join(process.cwd(), '.claude', 'settings.json');
+  if (existsSync(settingsPath)) {
+    try {
+      const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+      const hooks = settings.hooks ?? {};
+      const hasSession = (hooks.SessionStart ?? []).some(
+        (h: Record<string, string>) => h.command?.includes('session-start.mjs')
+      );
+      const hasPreEdit = (hooks.PreToolUse ?? []).some(
+        (h: Record<string, string>) => h.command?.includes('pre-edit.mjs')
+      );
+      if (hasSession && hasPreEdit) {
+        results.push({ name: 'Settings', status: 'ok', message: 'Both hooks registered in .claude/settings.json' });
+      } else {
+        const missing = [];
+        if (!hasSession) missing.push('SessionStart');
+        if (!hasPreEdit) missing.push('PreToolUse');
+        results.push({ name: 'Settings', status: 'warn', message: `Missing hooks: ${missing.join(', ')}. Run \`opentology context init\`.` });
+      }
+    } catch {
+      results.push({ name: 'Settings', status: 'warn', message: 'Cannot parse .claude/settings.json' });
+    }
+  } else {
+    results.push({ name: 'Settings', status: 'warn', message: 'No .claude/settings.json found. Run `opentology context init`.' });
+  }
+
+  // 6. CLAUDE.md
+  const claudeMdPath = join(process.cwd(), 'CLAUDE.md');
+  if (existsSync(claudeMdPath)) {
+    const content = readFileSync(claudeMdPath, 'utf-8');
+    if (content.includes('OPENTOLOGY:CONTEXT:BEGIN') || content.includes('OpenTology')) {
+      results.push({ name: 'CLAUDE.md', status: 'ok', message: 'Context section present' });
+    } else {
+      results.push({ name: 'CLAUDE.md', status: 'warn', message: 'Exists but no OpenTology context section' });
+    }
+  } else {
+    results.push({ name: 'CLAUDE.md', status: 'warn', message: 'Not found. Run `opentology context init`.' });
+  }
+
+  // 7. Optional dependencies
+  const optDeps: Array<{ name: string; desc: string }> = [
+    { name: 'ts-morph', desc: 'TypeScript deep scan' },
+    { name: 'web-tree-sitter', desc: 'Multi-language deep scan' },
+  ];
+  for (const dep of optDeps) {
+    try {
+      await import(dep.name);
+      results.push({ name: dep.name, status: 'ok', message: dep.desc });
+    } catch {
+      results.push({ name: dep.name, status: 'warn', message: `Not installed (optional — ${dep.desc})` });
+    }
+  }
+
+  return results;
+}
+
+export function registerDoctor(program: Command): void {
+  program
+    .command('doctor')
+    .description('Check project health: config, store, context, hooks, dependencies')
+    .option('--format <type>', 'Output format: table, json', 'table')
+    .action(async (opts: { format: string }) => {
+      const results = await runDoctor();
+
+      if (opts.format === 'json') {
+        console.log(JSON.stringify(results, null, 2));
+        return;
+      }
+
+      console.log(pc.bold('\nOpenTology Doctor\n'));
+      for (const r of results) {
+        const icon = r.status === 'ok' ? pc.green('✓') : r.status === 'warn' ? pc.yellow('!') : pc.red('✗');
+        const msg = r.status === 'fail' ? pc.red(r.message) : r.status === 'warn' ? pc.yellow(r.message) : r.message;
+        console.log(`  ${icon} ${pc.bold(r.name)}: ${msg}`);
+      }
+
+      const fails = results.filter((r) => r.status === 'fail').length;
+      const warns = results.filter((r) => r.status === 'warn').length;
+      console.log('');
+      if (fails > 0) {
+        console.log(pc.red(`  ${fails} error(s), ${warns} warning(s)`));
+        process.exit(1);
+      } else if (warns > 0) {
+        console.log(pc.yellow(`  ${warns} warning(s), everything else looks good`));
+      } else {
+        console.log(pc.green('  All checks passed!'));
+      }
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,11 +16,12 @@ import { registerInfer } from './commands/infer.js';
 import { registerPrefix } from './commands/prefix.js';
 import { registerContext } from './commands/context.js';
 import { registerViz } from './commands/viz.js';
+import { registerDoctor } from './commands/doctor.js';
 
 const program = new Command();
 program
   .name('opentology')
-  .version('0.1.0')
+  .version('0.2.2')
   .description('CLI-managed RDF/SPARQL infrastructure — Supabase for RDF');
 
 registerInit(program);
@@ -39,5 +40,6 @@ registerInfer(program);
 registerPrefix(program);
 registerContext(program);
 registerViz(program);
+registerDoctor(program);
 
 program.parse(process.argv);

--- a/src/lib/context-sync.ts
+++ b/src/lib/context-sync.ts
@@ -1,0 +1,274 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { OpenTologyConfig, addTrackedFile, saveConfig } from './config.js';
+import { createReadyAdapter } from './store-factory.js';
+import { extractDependencyGraph } from './codebase-scanner.js';
+
+export interface SyncResult {
+  sessionsRecovered: number;
+  modulesUpdated: boolean;
+  moduleStats: { modules: number; edges: number } | null;
+  actions: string[];
+}
+
+const OTX = 'https://opentology.dev/vocab#';
+const XSD = 'http://www.w3.org/2001/XMLSchema#';
+
+/**
+ * Get the most recent session date from the sessions graph.
+ * Returns ISO date string (YYYY-MM-DD) or null if no sessions exist.
+ */
+async function getLastSessionDate(
+  adapter: Awaited<ReturnType<typeof createReadyAdapter>>,
+  sessionsUri: string,
+): Promise<string | null> {
+  const r = await adapter.sparqlQuery(`
+    SELECT ?date WHERE {
+      GRAPH <${sessionsUri}> {
+        ?s a <${OTX}Session> ; <${OTX}date> ?date .
+      }
+    } ORDER BY DESC(?date) LIMIT 1
+  `);
+  const binding = r.results?.bindings?.[0];
+  return binding?.date?.value ?? null;
+}
+
+/**
+ * Get git commits since a given date, grouped by date.
+ * Returns map of date -> commit messages.
+ */
+function getCommitsSince(
+  projectRoot: string,
+  sinceDate: string | null,
+): Map<string, string[]> {
+  const dateMap = new Map<string, string[]>();
+
+  try {
+    const args = ['log', '--format=%ad|%s', '--date=short'];
+    if (sinceDate) {
+      args.push(`--after=${sinceDate}`);
+    } else {
+      args.push('--since=7 days ago');
+    }
+
+    const output = execFileSync('git', args, {
+      cwd: projectRoot,
+      encoding: 'utf-8',
+      timeout: 5000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+
+    if (!output) return dateMap;
+
+    for (const line of output.split('\n')) {
+      const sepIdx = line.indexOf('|');
+      if (sepIdx === -1) continue;
+      const date = line.slice(0, sepIdx).trim();
+      const msg = line.slice(sepIdx + 1).trim();
+      if (!date || !msg) continue;
+
+      if (!dateMap.has(date)) dateMap.set(date, []);
+      dateMap.get(date)!.push(msg);
+    }
+  } catch {
+    // git not available or not a repo
+  }
+
+  return dateMap;
+}
+
+/**
+ * Check if any source files changed since a given date.
+ */
+function hasSourceChanges(projectRoot: string, sinceDate: string | null): boolean {
+  if (!sinceDate) return true;
+
+  try {
+    const output = execFileSync('git', [
+      'log', '--oneline', `--after=${sinceDate}`,
+      '--', '*.ts', '*.js', '*.tsx', '*.jsx', '*.py', '*.go', '*.rs', '*.java', '*.swift',
+    ], {
+      cwd: projectRoot,
+      encoding: 'utf-8',
+      timeout: 5000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+
+    return output.length > 0;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Generate Turtle content for auto-recovered sessions.
+ */
+function generateSessionTurtle(commitsByDate: Map<string, string[]>): string {
+  const lines = [
+    `@prefix otx: <${OTX}> .`,
+    `@prefix xsd: <${XSD}> .`,
+    '',
+  ];
+
+  for (const [date, messages] of commitsByDate) {
+    const title = messages.length === 1
+      ? messages[0]
+      : `${messages.length} commits`;
+    const body = messages.join('\n');
+    const uri = `urn:session:${date}-auto`;
+
+    lines.push(`<${uri}> a otx:Session ;`);
+    lines.push(`    otx:title "${escapeTurtle(title)}" ;`);
+    lines.push(`    otx:date "${date}"^^xsd:date ;`);
+    lines.push(`    otx:body "${escapeTurtle(body)}" .`);
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Generate Turtle content for module dependency graph.
+ */
+function generateModuleTurtle(modules: string[], edges: { from: string; to: string }[]): string {
+  const lines = [
+    `@prefix otx: <${OTX}> .`,
+    '',
+  ];
+
+  for (const mod of modules) {
+    lines.push(`<urn:module:${mod}> a otx:Module .`);
+  }
+  lines.push('');
+
+  for (const edge of edges) {
+    lines.push(`<urn:module:${edge.from}> otx:dependsOn <urn:module:${edge.to}> .`);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Core sync logic: recover missed sessions and rescan modules.
+ * Persists via .ttl files for embedded mode compatibility.
+ */
+export async function syncContext(
+  config: OpenTologyConfig,
+  projectRoot: string,
+): Promise<SyncResult> {
+  const graphs = config.graphs ?? {};
+  const contextUri = graphs['context'];
+  const sessionsUri = graphs['sessions'];
+
+  if (!contextUri || !sessionsUri) {
+    throw new Error('Context not initialized. Run `opentology context init` first.');
+  }
+
+  const adapter = await createReadyAdapter(config);
+  const actions: string[] = [];
+  let sessionsRecovered = 0;
+  let modulesUpdated = false;
+  let moduleStats: { modules: number; edges: number } | null = null;
+
+  const syncDir = join(projectRoot, '.opentology', 'sync');
+  mkdirSync(syncDir, { recursive: true });
+
+  // === Step 1: Recover missed sessions from git log ===
+  const lastDate = await getLastSessionDate(adapter, sessionsUri);
+  const commitsByDate = getCommitsSince(projectRoot, lastDate);
+
+  if (commitsByDate.size > 0) {
+    const turtle = generateSessionTurtle(commitsByDate);
+    const sessionsFile = join(syncDir, 'auto-sessions.ttl');
+
+    // Append to existing auto-sessions file or create new
+    if (existsSync(sessionsFile)) {
+      const existing = readFileSync(sessionsFile, 'utf-8');
+      // Only add new sessions (check URIs)
+      const newEntries: string[] = [];
+      for (const [date] of commitsByDate) {
+        const uri = `urn:session:${date}-auto`;
+        if (!existing.includes(uri)) {
+          newEntries.push(date);
+        }
+      }
+      if (newEntries.length > 0) {
+        const newMap = new Map<string, string[]>();
+        for (const date of newEntries) {
+          newMap.set(date, commitsByDate.get(date)!);
+        }
+        if (newMap.size > 0) {
+          const newTurtle = generateSessionTurtle(newMap);
+          // Remove prefix lines from appended content
+          const body = newTurtle.split('\n').filter(l => !l.startsWith('@prefix') && l.trim() !== '').join('\n');
+          writeFileSync(sessionsFile, existing.trimEnd() + '\n\n' + body + '\n', 'utf-8');
+          await adapter.insertTurtle(sessionsUri, newTurtle);
+          sessionsRecovered = newMap.size;
+        }
+      }
+    } else {
+      writeFileSync(sessionsFile, turtle, 'utf-8');
+      await adapter.insertTurtle(sessionsUri, turtle);
+      sessionsRecovered = commitsByDate.size;
+    }
+
+    if (sessionsRecovered > 0) {
+      // Track the file for embedded persistence
+      const relPath = '.opentology/sync/auto-sessions.ttl';
+      addTrackedFile(config, sessionsUri, relPath);
+
+      const totalCommits = [...commitsByDate.values()].reduce((s, m) => s + m.length, 0);
+      actions.push(`Recovered ${sessionsRecovered} session(s) from ${totalCommits} git commit(s)`);
+    } else {
+      actions.push('No missed sessions to recover');
+    }
+  } else {
+    actions.push('No missed sessions to recover');
+  }
+
+  // === Step 2: Rescan module dependency graph if source files changed ===
+  const shouldRescan = hasSourceChanges(projectRoot, lastDate);
+
+  if (shouldRescan) {
+    try {
+      const dg = await extractDependencyGraph(projectRoot, null);
+      if (dg.modules.length > 0) {
+        const turtle = generateModuleTurtle(dg.modules, dg.edges);
+        const modulesFile = join(syncDir, 'modules.ttl');
+
+        // Replace modules file entirely (fresh scan)
+        writeFileSync(modulesFile, turtle, 'utf-8');
+
+        // Drop old module triples, then insert fresh
+        await adapter.sparqlUpdate(
+          `DELETE { GRAPH <${contextUri}> { ?s ?p ?o } } WHERE { GRAPH <${contextUri}> { ?s a <${OTX}Module> . ?s ?p ?o } }`
+        );
+        await adapter.sparqlUpdate(
+          `DELETE { GRAPH <${contextUri}> { ?s <${OTX}dependsOn> ?o } } WHERE { GRAPH <${contextUri}> { ?s <${OTX}dependsOn> ?o } }`
+        );
+        await adapter.insertTurtle(contextUri, turtle);
+
+        const relPath = '.opentology/sync/modules.ttl';
+        addTrackedFile(config, contextUri, relPath);
+
+        moduleStats = { modules: dg.modules.length, edges: dg.edges.length };
+        modulesUpdated = true;
+        actions.push(`Rescanned modules: ${dg.modules.length} modules, ${dg.edges.length} edges`);
+      }
+    } catch {
+      actions.push('Module rescan failed (non-fatal)');
+    }
+  } else {
+    actions.push('No source changes detected — module rescan skipped');
+  }
+
+  // Save config with tracked files
+  saveConfig(config);
+
+  return { sessionsRecovered, modulesUpdated, moduleStats, actions };
+}
+
+function escapeTurtle(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -20,7 +20,7 @@ import { discoverShapes, validateWithShacl, hasShapes } from '../lib/shacl.js';
 import { materializeInferences, clearInferences } from '../lib/reasoner.js';
 import { fromSchemaData, toMermaid, toDot } from '../lib/visualizer.js';
 import type { InferenceResult } from '../lib/reasoner.js';
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { OTX_BOOTSTRAP_TURTLE } from '../templates/otx-ontology.js';
 import { generateContextSection, updateClaudeMd } from '../templates/claude-md-context.js';
@@ -28,6 +28,8 @@ import { generateHookScript } from '../templates/session-start-hook.js';
 import { generatePreEditHookScript } from '../templates/pre-edit-hook.js';
 import { generateSlashCommands } from '../templates/slash-commands.js';
 import type { ContextLoadOutput } from '../commands/context.js';
+import { runDoctor } from '../commands/doctor.js';
+import { syncContext } from '../lib/context-sync.js';
 import { scanCodebase } from '../lib/codebase-scanner.js';
 import { startGraphServer } from '../lib/graph-server.js';
 
@@ -539,6 +541,51 @@ async function handleContextInit(args: Record<string, unknown>): Promise<unknown
 
   saveConfig(config);
 
+  // Auto-register hooks in .claude/settings.json (non-interactive, both hooks)
+  const settingsDir = join(process.cwd(), '.claude');
+  const settingsPath = join(settingsDir, 'settings.json');
+  mkdirSync(settingsDir, { recursive: true });
+
+  let settings: Record<string, unknown> = {};
+  if (existsSync(settingsPath)) {
+    try {
+      settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    } catch { /* start fresh */ }
+  }
+
+  const hooks = (settings.hooks ?? {}) as Record<string, unknown[]>;
+  let hooksChanged = false;
+
+  const sessionStartCmd = 'node .opentology/hooks/session-start.mjs';
+  if (!hooks.SessionStart) hooks.SessionStart = [];
+  const hasSessionHook = hooks.SessionStart.some(
+    (h: unknown) => (h as Record<string, string>).command === sessionStartCmd
+  );
+  if (!hasSessionHook) {
+    hooks.SessionStart.push({ type: 'command', command: sessionStartCmd });
+    hooksChanged = true;
+  }
+
+  const preEditCmd = 'node .opentology/hooks/pre-edit.mjs';
+  if (!hooks.PreToolUse) hooks.PreToolUse = [];
+  const hasPreEditHook = hooks.PreToolUse.some(
+    (h: unknown) => (h as Record<string, string>).command === preEditCmd
+  );
+  if (!hasPreEditHook) {
+    hooks.PreToolUse.push({
+      type: 'command',
+      command: preEditCmd,
+      matcher: { tool_name: 'Edit|Write' },
+    });
+    hooksChanged = true;
+  }
+
+  if (hooksChanged) {
+    settings.hooks = hooks;
+    writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n', 'utf-8');
+    actions.push('Auto-registered hooks in .claude/settings.json');
+  }
+
   // Auto-push Module triples from dependency graph
   let moduleStats: { modules: number; edges: number } | null = null;
   try {
@@ -573,19 +620,7 @@ async function handleContextInit(args: Record<string, unknown>): Promise<unknown
     actions,
     moduleStats,
     dependencyHint,
-    hookSnippet: {
-      hooks: {
-        SessionStart: [{
-          type: 'command',
-          command: 'node .opentology/hooks/session-start.mjs',
-        }],
-        PreToolUse: [{
-          type: 'command',
-          command: 'node .opentology/hooks/pre-edit.mjs',
-          matcher: { tool_name: 'Edit|Write' },
-        }],
-      },
-    },
+    hooksAutoInstalled: hooksChanged,
   };
 }
 
@@ -1302,6 +1337,22 @@ export async function startMcpServer(): Promise<void> {
           required: ['filePath'],
         },
       },
+      {
+        name: 'context_sync',
+        description: 'Auto-sync context graph: recover missed sessions from git log and rescan module dependency graph. Call this at session start to ensure the graph is up to date. Idempotent — safe to call multiple times.',
+        inputSchema: {
+          type: 'object' as const,
+          properties: {},
+        },
+      },
+      {
+        name: 'doctor',
+        description: 'Check project health: config, store connectivity, context initialization, hook scripts, Claude Code settings, and optional dependencies. Returns a list of checks with ok/warn/fail status.',
+        inputSchema: {
+          type: 'object' as const,
+          properties: {},
+        },
+      },
     ],
   }));
 
@@ -1375,6 +1426,12 @@ export async function startMcpServer(): Promise<void> {
         }
         case 'context_impact':
           result = await handleContextImpact(args as Record<string, unknown>);
+          break;
+        case 'context_sync':
+          result = await syncContext(loadConfig(), process.cwd());
+          break;
+        case 'doctor':
+          result = await runDoctor();
           break;
         default:
           throw new Error(`Unknown tool: ${name}`);

--- a/src/templates/session-start-hook.ts
+++ b/src/templates/session-start-hook.ts
@@ -74,6 +74,26 @@ try {
   const projectRoot = findProjectRoot(process.cwd());
   if (!projectRoot) process.exit(0);
 
+  // Step 1: Auto-sync — recover missed sessions and rescan modules
+  let syncSummary = '';
+  try {
+    const syncRaw = run(projectRoot, ['context', 'sync', '--format', 'json']);
+    const syncData = JSON.parse(syncRaw);
+    const parts = [];
+    if (syncData.sessionsRecovered > 0) {
+      parts.push(\`\${syncData.sessionsRecovered} session(s) recovered from git\`);
+    }
+    if (syncData.modulesUpdated) {
+      parts.push(\`modules rescanned (\${syncData.moduleStats?.modules ?? 0} modules)\`);
+    }
+    if (parts.length > 0) {
+      syncSummary = 'Auto-sync: ' + parts.join(', ') + '.';
+    }
+  } catch {
+    // Sync failed — continue with load
+  }
+
+  // Step 2: Load context
   const raw = run(projectRoot, ['context', 'load', '--format', 'json']);
   const data = JSON.parse(raw);
 
@@ -82,8 +102,15 @@ try {
                   (data.recentDecisions?.length > 0);
 
   if (hasData) {
-    console.log(formatOutput(data));
+    const output = formatOutput(data);
+    if (syncSummary) {
+      console.log(syncSummary + '\\n');
+    }
+    console.log(output);
   } else {
+    if (syncSummary) {
+      console.log(syncSummary);
+    }
     console.log(\`OpenTology context active for \${data.projectId}. No session data yet.\`);
   }
 } catch {


### PR DESCRIPTION
## Summary

Closes #34

- **`context sync`** CLI + MCP 도구: SessionStart 시 git log에서 누락 세션 자동 복구 + 모듈 의존성 그래프 재스캔
- **`opentology doctor`** CLI + MCP 도구: 설정/스토어/컨텍스트/훅/의존성 헬스체크
- **GitHub Actions CI**: Node 20/22 매트릭스로 빌드+테스트
- **태그 기반 npm publish**: `v*` 태그 push 시 자동 배포 (`--provenance`)
- **Hook 자동 설치**: MCP `context_init`이 `.claude/settings.json`에 hook 자동 등록
- **v0.2.2**: 23개 MCP 도구, 18개 CLI 명령어

## Test plan

- [x] `npm run build` 통과
- [x] `npm test` 116/116 통과
- [x] `opentology context sync` 세션 복구 + 모듈 재스캔 동작 확인
- [x] 두번째 실행 시 멱등성 확인 (no-op)
- [x] `opentology doctor` 헬스체크 동작 확인
- [x] 아키텍트 리뷰 통과 (버그 3개 수정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)