### PR TITLE
fix: use correct Claude Code hook schema in context init

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .opentology/hooks/session-start.mjs"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .opentology/hooks/pre-edit.mjs"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -205,10 +205,17 @@ export function registerContext(program: Command): void {
         const sessionStartCmd = 'node .opentology/hooks/session-start.mjs';
         if (!hooks.SessionStart) hooks.SessionStart = [];
         const hasSessionHook = hooks.SessionStart.some(
-          (h: unknown) => (h as Record<string, string>).command === sessionStartCmd
+          (h: unknown) => {
+            const entry = h as Record<string, unknown>;
+            const entryHooks = entry.hooks as Array<Record<string, string>> | undefined;
+            return entryHooks?.some((hook) => hook.command === sessionStartCmd);
+          }
         );
         if (!hasSessionHook) {
-          hooks.SessionStart.push({ type: 'command', command: sessionStartCmd });
+          hooks.SessionStart.push({
+            matcher: '',
+            hooks: [{ type: 'command', command: sessionStartCmd }],
+          });
           console.log(pc.green('  Registered SessionStart hook in .claude/settings.json'));
         }
 
@@ -224,13 +231,16 @@ export function registerContext(program: Command): void {
           const preEditCmd = 'node .opentology/hooks/pre-edit.mjs';
           if (!hooks.PreToolUse) hooks.PreToolUse = [];
           const hasPreEditHook = hooks.PreToolUse.some(
-            (h: unknown) => (h as Record<string, string>).command === preEditCmd
+            (h: unknown) => {
+              const entry = h as Record<string, unknown>;
+              const entryHooks = entry.hooks as Array<Record<string, string>> | undefined;
+              return entryHooks?.some((hook) => hook.command === preEditCmd);
+            }
           );
           if (!hasPreEditHook) {
             hooks.PreToolUse.push({
-              type: 'command',
-              command: preEditCmd,
-              matcher: { tool_name: 'Edit|Write' },
+              matcher: 'Edit|Write',
+              hooks: [{ type: 'command', command: preEditCmd }],
             });
           }
           console.log(pc.green('  Registered PreToolUse impact hook in .claude/settings.json'));


### PR DESCRIPTION
## Summary
- Fix `context init` hook registration to use correct `{ matcher: string, hooks: [...] }` schema
- Fix existing `.claude/settings.json` in this repo

Closes #36

## Test plan
- [x] `npm run build` passes
- [x] 116 tests pass
- [x] Verified `.claude/settings.json` no longer triggers schema errors on session start

🤖 Generated with [Claude Code](https://claude.com/claude-code)