### PR TITLE
fix: normalize module URIs so context impact returns correct results

### DIFF
--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -12,6 +12,7 @@ import { generateContextSection, updateClaudeMd } from '../templates/claude-md-c
 import { generateHookScript } from '../templates/session-start-hook.js';
 import { generatePreEditHookScript } from '../templates/pre-edit-hook.js';
 import { generateSlashCommands } from '../templates/slash-commands.js';
+import { normalizeModuleUri } from '../lib/module-uri.js';
 
 function ask(question: string): Promise<string> {
   const rl = createInterface({ input: process.stdin, output: process.stdout });
@@ -499,7 +500,7 @@ export function registerContext(program: Command): void {
 
       const contextUri = graphs['context'];
       const OTX = 'https://opentology.dev/vocab#';
-      const moduleUriStr = `urn:module:${opts.file}`;
+      const moduleUriStr = normalizeModuleUri(opts.file);
 
       try {
         const adapter = await createReadyAdapter(config);

--- a/src/lib/codebase-scanner.ts
+++ b/src/lib/codebase-scanner.ts
@@ -2,6 +2,7 @@ import { readFile, readdir } from 'node:fs/promises';
 import { join, relative } from 'node:path';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { stripSourceExtension } from './module-uri.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -254,7 +255,7 @@ export async function extractDependencyGraph(rootDir: string, gitFiles: Set<stri
   const edges: DependencyEdge[] = [];
 
   for (const filePath of sourceFiles) {
-    const moduleName = filePath.replace(/\.[tj]sx?$/, '');
+    const moduleName = stripSourceExtension(filePath);
     moduleSet.add(moduleName);
 
     let content: string;

--- a/src/lib/module-uri.ts
+++ b/src/lib/module-uri.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared module URI normalization — single source of truth for
+ * converting file paths to urn:module: URIs.
+ */
+
+const SOURCE_EXT_RE = /\.[tj]sx?$/;
+
+export function stripSourceExtension(filePath: string): string {
+  return filePath.replace(SOURCE_EXT_RE, '');
+}
+
+export function normalizeModuleUri(filePath: string): string {
+  return `urn:module:${stripSourceExtension(filePath)}`;
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -13,6 +13,7 @@ import { deepScan } from '../lib/deep-scanner.js';
 import { pushSymbolTriples } from '../lib/deep-scan-triples.js';
 import type { OpenTologyConfig } from '../lib/config.js';
 import { createReadyAdapter } from '../lib/store-factory.js';
+import { normalizeModuleUri } from '../lib/module-uri.js';
 import type { StoreAdapter } from '../lib/store-adapter.js';
 import { hasGraphScope, autoScopeQuery, getInferenceGraphUri } from '../lib/sparql-utils.js';
 import { validateTurtle } from '../lib/validator.js';
@@ -725,7 +726,7 @@ async function handleContextImpact(args: Record<string, unknown>): Promise<unkno
   const contextUri = `${config.graphUri}/context`;
   const adapter = await createReadyAdapter(config);
   const OTX = 'https://opentology.dev/vocab#';
-  const moduleUriStr = `urn:module:${filePath}`;
+  const moduleUriStr = normalizeModuleUri(filePath);
 
   // 1. Modules that depend on this file (dependents / reverse deps)
   const dependentsQuery = `

--- a/tests/unit/module-uri.test.ts
+++ b/tests/unit/module-uri.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { stripSourceExtension, normalizeModuleUri } from '../../src/lib/module-uri.js';
+
+describe('stripSourceExtension', () => {
+  it('strips .ts extension', () => {
+    expect(stripSourceExtension('src/lib/foo.ts')).toBe('src/lib/foo');
+  });
+
+  it('strips .tsx extension', () => {
+    expect(stripSourceExtension('src/components/Bar.tsx')).toBe('src/components/Bar');
+  });
+
+  it('strips .js extension', () => {
+    expect(stripSourceExtension('src/lib/foo.js')).toBe('src/lib/foo');
+  });
+
+  it('strips .jsx extension', () => {
+    expect(stripSourceExtension('src/components/Bar.jsx')).toBe('src/components/Bar');
+  });
+
+  it('is idempotent — no extension returns unchanged', () => {
+    expect(stripSourceExtension('src/lib/foo')).toBe('src/lib/foo');
+  });
+
+  it('does not strip non-source extensions', () => {
+    expect(stripSourceExtension('data/config.json')).toBe('data/config.json');
+    expect(stripSourceExtension('README.md')).toBe('README.md');
+  });
+});
+
+describe('normalizeModuleUri', () => {
+  it('produces urn:module: with stripped extension', () => {
+    expect(normalizeModuleUri('src/lib/store-factory.ts')).toBe('urn:module:src/lib/store-factory');
+  });
+
+  it('handles path without extension', () => {
+    expect(normalizeModuleUri('src/lib/store-factory')).toBe('urn:module:src/lib/store-factory');
+  });
+});


### PR DESCRIPTION
## Summary
- `context impact` was always returning empty results due to URI normalization mismatch
- Scan stored `urn:module:src/lib/foo` (no extension), queries used `urn:module:src/lib/foo.ts`
- Created shared `normalizeModuleUri`/`stripSourceExtension` utility
- Fixed 2 query sites: `context.ts`, `server.ts`
- Unified `codebase-scanner.ts` inline regex with shared utility

Closes #40

## Test plan
- [x] `npm run build` — zero errors
- [x] `npm test` — 124 tests pass (14 files)
- [x] Smoke test: `context impact --file src/lib/store-factory.ts` returns 16 dependents + 5 dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)