### PR TITLE
feat: add Pre-Analysis Context Check to CLAUDE.md template (#44)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentology",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Ontology-powered project memory for AI coding assistants — your codebase as a knowledge graph",
   "type": "module",
   "bin": {

--- a/src/templates/claude-md-context.ts
+++ b/src/templates/claude-md-context.ts
@@ -74,6 +74,30 @@ SELECT ?title ?date WHERE {
 
 OpenTology provides MCP tools to query and manage the project knowledge graph. Use them proactively.
 
+#### Pre-Analysis Context Check
+
+Before exploring code or analyzing architecture, query the knowledge graph for existing context:
+- **Decisions**: past architectural choices that may inform the current analysis
+- **Knowledge**: reusable patterns or lessons already recorded
+- **Issues**: known problems related to the area under investigation
+- **Sessions**: recent work in the same area
+
+\`\`\`sparql
+PREFIX otx: <https://opentology.dev/vocab#>
+SELECT ?type ?title ?body WHERE {
+  GRAPH <${contextUri}> {
+    { ?s a otx:Decision ; otx:title ?title ; otx:body ?body . BIND("decision" AS ?type) }
+    UNION
+    { ?s a otx:Knowledge ; otx:title ?title ; otx:body ?body . BIND("knowledge" AS ?type) }
+    UNION
+    { ?s a otx:Issue ; otx:title ?title ; otx:body ?body . BIND("issue" AS ?type) }
+  }
+  FILTER(CONTAINS(LCASE(?title), "keyword") || CONTAINS(LCASE(?body), "keyword"))
+} LIMIT 10
+\`\`\`
+
+This prevents redundant analysis and ensures past decisions and knowledge inform current work.
+
 #### Pre-Edit Impact Check
 
 Before modifying a file, run \`context_impact\` with the target file path to understand the blast radius:


### PR DESCRIPTION
## Summary
- AI가 코드 분석/조사 시작 전에 기존 Decision/Knowledge/Issue를 먼저 query하도록 하는 행동 지침을 CLAUDE.md 템플릿에 추가
- `context_init` 실행 시 생성되는 CLAUDE.md에 Pre-Analysis Context Check 섹션이 포함됨
- Version bump to 0.2.6

Closes #44

## Test plan
- [x] `npm run build` 통과
- [x] `npm test` 124/124 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)