### PR TITLE
fix: add persistGraph to handleInfer and context_sync (#52)

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -435,10 +435,12 @@ async function handleInfer(args: Record<string, unknown>): Promise<unknown> {
   if (clear) {
     await snapshotGraph(adapter, config, graphUri);
     await clearInferences(adapter, graphUri);
+    await persistGraph(adapter, config, graphUri);
     return { success: true, cleared: true };
   }
 
   const result: InferenceResult = await materializeInferences(adapter, graphUri);
+  await persistGraph(adapter, config, graphUri);
   return result;
 }
 
@@ -1545,9 +1547,12 @@ export async function startMcpServer(): Promise<void> {
         case 'context_sync': {
           const syncConfig = loadConfig();
           const syncContextUri = `${syncConfig.graphUri}/context`;
+          const syncSessionsUri = `${syncConfig.graphUri}/sessions`;
           const syncAdapter = await createReadyAdapter(syncConfig);
           await snapshotGraph(syncAdapter, syncConfig, syncContextUri);
           result = await syncContext(syncConfig, process.cwd());
+          await persistGraph(syncAdapter, syncConfig, syncContextUri);
+          await persistGraph(syncAdapter, syncConfig, syncSessionsUri);
           break;
         }
         case 'rollback':


### PR DESCRIPTION
## Summary
- `handleInfer` (both `clear` and `materialize` paths) was missing `persistGraph` calls — embedded-mode inferences were lost on process restart
- `context_sync` inline handler called `syncContext()` but never persisted the updated context/sessions graphs via `persistGraph`

Closes #52

## Test plan
- [x] `npm run build` passes
- [x] All 142 tests pass (`npm test`)
- [x] Verified all MCP mutation handlers now call `persistGraph`

🤖 Generated with [Claude Code](https://claude.com/claude-code)