### PR TITLE
feat: MethodCall triples + graph-first knowledge wiki (#55)

### DIFF
--- a/src/lib/deep-scan-triples.ts
+++ b/src/lib/deep-scan-triples.ts
@@ -92,11 +92,11 @@ export function generateSymbolTriples(result: DeepScanResult): string[] {
   }
 
   for (const call of result.methodCalls) {
-    // Method calls reference by class.method pattern — generate a simple triple
-    triples.push(`<urn:call:${encodeSegment(call.caller)}> <${OTX}calls> <urn:call:${encodeSegment(call.callee)}> .`);
-    // Store caller/callee names for queryability
-    triples.push(`<urn:call:${encodeSegment(call.caller)}> <${OTX}title> "${esc(call.caller)}" .`);
-    triples.push(`<urn:call:${encodeSegment(call.callee)}> <${OTX}title> "${esc(call.callee)}" .`);
+    const callUri = `urn:call:${encodeSegment(call.caller)}--${encodeSegment(call.callee)}`;
+    triples.push(`<${callUri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <${OTX}MethodCall> .`);
+    triples.push(`<${callUri}> <${OTX}callerSymbol> "${esc(call.caller)}" .`);
+    triples.push(`<${callUri}> <${OTX}calleeSymbol> "${esc(call.callee)}" .`);
+    triples.push(`<${callUri}> <${OTX}title> "${esc(call.caller)} -> ${esc(call.callee)}" .`);
   }
 
   return triples;
@@ -129,6 +129,10 @@ export async function deleteExistingSymbols(
       `DELETE WHERE { GRAPH <${graphUri}> { ?s <${OTX}definedIn> <${modUri}> . ?s ?p ?o } }`
     );
   }
+  // Clean up MethodCall triples (no definedIn link, so delete all and re-insert)
+  await adapter.sparqlUpdate(
+    `DELETE WHERE { GRAPH <${graphUri}> { ?s a <${OTX}MethodCall> . ?s ?p ?o } }`
+  );
 }
 
 export async function pushSymbolTriples(

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -477,7 +477,7 @@ async function handleContextScan(args: Record<string, unknown>): Promise<unknown
       pushStats,
       _experimental: true,
       _hint: pushStats
-        ? `Symbol triples pushed: ${pushStats.triplesInserted} triples in ${pushStats.batchCount} batches. Query with: SELECT ?c WHERE { ?c a otx:Class ; otx:definedIn <urn:module:...> }`
+        ? `Symbol triples pushed: ${pushStats.triplesInserted} triples in ${pushStats.batchCount} batches. Query examples:\n- Classes: SELECT ?c ?name WHERE { ?c a otx:Class ; otx:title ?name }\n- Functions in a module: SELECT ?f ?name WHERE { ?f a otx:Function ; otx:title ?name ; otx:definedIn <urn:module:src/mcp/server> }\n- Call graph: SELECT ?caller ?callee WHERE { ?s a otx:MethodCall ; otx:callerSymbol ?caller ; otx:calleeSymbol ?callee }`
         : 'Deep scan completed but triple push failed. Use push manually with the generated triples.',
     };
   }
@@ -711,6 +711,7 @@ async function handleContextInit(args: Record<string, unknown>): Promise<unknown
     moduleStats,
     dependencyHint,
     hooksAutoInstalled: hooksChanged,
+    scanSuggestion: 'Run context_scan to populate the knowledge graph. Use depth="module" for file-level dependencies, or depth="symbol" (with includeMethodCalls=true) for class/function/call-level analysis. The symbol scan enables queries like "which functions call persistGraph?" from the graph.',
   };
 }
 

--- a/src/templates/claude-md-context.ts
+++ b/src/templates/claude-md-context.ts
@@ -29,6 +29,12 @@ This project uses OpenTology as its project context graph.
 | \`otx:Knowledge\` | Reusable knowledge |
 | \`otx:Session\` | Session logs |
 | \`otx:Pattern\` | Recurring patterns/conventions |
+| \`otx:Module\` | Source file module |
+| \`otx:Class\` | Class definition (symbol scan) |
+| \`otx:Interface\` | Interface definition (symbol scan) |
+| \`otx:Function\` | Function definition (symbol scan) |
+| \`otx:Method\` | Method definition (symbol scan) |
+| \`otx:MethodCall\` | Call relationship between symbols (symbol scan) |
 
 | Property | Range | Description |
 |----------|-------|-------------|
@@ -39,6 +45,11 @@ This project uses OpenTology as its project context graph.
 | \`otx:reason\` | string | Decision rationale |
 | \`otx:nextTodo\` | string | Next action item |
 | \`otx:relatedTo\` | resource | Related entity |
+| \`otx:dependsOn\` | Module | Module import dependency |
+| \`otx:definedIn\` | Module | Which module a symbol belongs to |
+| \`otx:callerSymbol\` | string | Caller in a MethodCall |
+| \`otx:calleeSymbol\` | string | Callee in a MethodCall |
+| \`otx:calls\` | resource | Call relationship |
 
 ### When to Record
 
@@ -110,13 +121,48 @@ If impact is **high**, inform the user of affected modules and get confirmation 
 
 #### Searching the Knowledge Graph
 
-Use \`query\` with SPARQL to find anything in the project graph:
+Use \`query\` with SPARQL to find anything in the project graph. **Always query the graph before reading source files** when investigating code structure, dependencies, or call relationships:
+
 - **Decisions**: \`?s a otx:Decision\` — why architectural choices were made
 - **Issues**: \`?s a otx:Issue ; otx:status "open"\` — known bugs and their status
 - **Knowledge**: \`?s a otx:Knowledge\` — reusable patterns and lessons learned
 - **Sessions**: query the sessions graph for past work logs and next TODOs
 - **Modules**: \`?s a otx:Module\` — all scanned source modules and their dependencies (\`otx:dependsOn\`)
 - **Symbols**: \`?s a otx:Class\`, \`otx:Interface\`, \`otx:Function\`, \`otx:Method\` — code-level entities (available after symbol-depth scan)
+- **Call graph**: \`?s a otx:MethodCall\` — who calls whom (available after symbol scan with \`includeMethodCalls=true\`)
+
+\`\`\`sparql
+# Functions in a specific module
+PREFIX otx: <https://opentology.dev/vocab#>
+SELECT ?name WHERE {
+  GRAPH <${contextUri}> {
+    ?f a otx:Function ; otx:title ?name ; otx:definedIn <urn:module:src/mcp/server> .
+  }
+}
+
+# Who calls a specific function?
+PREFIX otx: <https://opentology.dev/vocab#>
+SELECT ?caller WHERE {
+  GRAPH <${contextUri}> {
+    ?s a otx:MethodCall ; otx:callerSymbol ?caller ; otx:calleeSymbol ?callee .
+    FILTER(CONTAINS(?callee, "persistGraph"))
+  }
+}
+
+# Module dependency chain (what depends on a module?)
+PREFIX otx: <https://opentology.dev/vocab#>
+SELECT ?dependent WHERE {
+  GRAPH <${contextUri}> {
+    ?dependent otx:dependsOn+ <urn:module:src/lib/store-adapter> .
+  }
+}
+\`\`\`
+
+#### Post-Edit Graph Update
+
+After significant code changes (new files, renamed functions, changed dependencies), run \`context_scan\` to keep the knowledge graph in sync:
+- \`depth="module"\` — fast, updates file-level imports
+- \`depth="symbol"\` with \`includeMethodCalls=true\` — thorough, updates class/function/call graph
 
 #### Other Useful Tools
 

--- a/src/templates/otx-ontology.ts
+++ b/src/templates/otx-ontology.ts
@@ -30,12 +30,15 @@ otx:Class a owl:Class .
 otx:Interface a owl:Class .
 otx:Function a owl:Class .
 otx:Method a owl:Class .
+otx:MethodCall a owl:Class .
 
 otx:definedIn a owl:ObjectProperty ; rdfs:range otx:Module .
 otx:extends a owl:ObjectProperty ; rdfs:domain otx:Class ; rdfs:range otx:Class .
 otx:implements a owl:ObjectProperty ; rdfs:domain otx:Class ; rdfs:range otx:Interface .
 otx:hasMethod a owl:ObjectProperty ; rdfs:domain otx:Class ; rdfs:range otx:Method .
-otx:calls a owl:ObjectProperty ; rdfs:domain otx:Method ; rdfs:range otx:Method .
+otx:calls a owl:ObjectProperty .
+otx:callerSymbol a owl:ObjectProperty ; rdfs:domain otx:MethodCall .
+otx:calleeSymbol a owl:ObjectProperty ; rdfs:domain otx:MethodCall .
 otx:returns a owl:DatatypeProperty ; rdfs:range xsd:string .
 otx:paramType a owl:DatatypeProperty ; rdfs:range xsd:string .
 `;

--- a/tests/unit/deep-scan-triples.test.ts
+++ b/tests/unit/deep-scan-triples.test.ts
@@ -161,6 +161,38 @@ describe('generateSymbolTriples', () => {
     expect(ifaceTriple).toBeDefined();
   });
 
+  it('produces otx:MethodCall triples with caller/callee symbols', () => {
+    const result = makeResult({
+      methodCalls: [
+        { caller: 'Foo.bar', callee: 'Baz.qux' },
+        { caller: 'handlePush', callee: 'persistGraph' },
+      ],
+    });
+
+    const triples = generateSymbolTriples(result);
+
+    // Should have rdf:type MethodCall
+    const typeTriples = triples.filter(t => t.includes('vocab#MethodCall'));
+    expect(typeTriples.length).toBe(2);
+
+    // Should have callerSymbol and calleeSymbol
+    const callerTriples = triples.filter(t => t.includes('vocab#callerSymbol'));
+    expect(callerTriples.length).toBe(2);
+    const calleeTriples = triples.filter(t => t.includes('vocab#calleeSymbol'));
+    expect(calleeTriples.length).toBe(2);
+
+    // Should have title with "caller -> callee" format
+    const titleTriples = triples.filter(t => t.includes('->'));
+    expect(titleTriples.length).toBe(2);
+    expect(titleTriples[0]).toContain('Foo.bar');
+    expect(titleTriples[0]).toContain('Baz.qux');
+
+    // Should parse as valid N-Triples
+    const parser = new Parser({ format: 'N-Triples' });
+    const quads = parser.parse(triples.join('\n'));
+    expect(quads.length).toBeGreaterThan(0);
+  });
+
   it('produces otx:Function triple for functions', () => {
     const result = makeResult({
       functions: [{


### PR DESCRIPTION
## Summary
- Add `otx:MethodCall` class to ontology bootstrap with `callerSymbol`/`calleeSymbol` properties
- Fix `generateSymbolTriples` to emit `rdf:type otx:MethodCall` triples (previously generated call triples without type, making them unqueryable)
- Fix `deleteExistingSymbols` to clean up stale MethodCall triples on rescan
- Add scan suggestion to `context_init` response guiding users to populate the knowledge graph
- Enrich CLAUDE.md template with full symbol ontology docs, call graph query examples, and post-edit graph update workflow
- Add MethodCall unit test with N-Triples parse validation

Closes #54, closes #55

## Verified end-to-end
- `generateSymbolTriples` produces correct `otx:MethodCall` triples
- SPARQL query `?s a otx:MethodCall ; otx:calleeSymbol "persistGraph"` returns correct callers
- `deleteExistingSymbols` cleans up all MethodCall triples
- 143 tests passing

## Test plan
- [x] Unit test: MethodCall triple generation with caller/callee/title
- [x] E2E script: insert → query → cleanup roundtrip
- [x] `npm run build` passes
- [x] All 143 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)