### PR TITLE
fix: limit diff output to prevent LLM context explosion (#57)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentology",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Ontology-powered project memory for AI coding assistants — your codebase as a knowledge graph",
   "type": "module",
   "bin": {

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -32,7 +32,13 @@ export function registerDiff(program: Command): void {
           console.log(pc.red(`- ${triple}`));
         }
 
-        console.log(`\n${result.added.length} added, ${result.removed.length} removed, ${result.unchanged} unchanged`);
+        const addedLabel = result.truncated && result.addedCount > result.added.length
+          ? `${result.added.length}/${result.addedCount} added (truncated)`
+          : `${result.addedCount} added`;
+        const removedLabel = result.truncated && result.removedCount > result.removed.length
+          ? `${result.removed.length}/${result.removedCount} removed (truncated)`
+          : `${result.removedCount} removed`;
+        console.log(`\n${addedLabel}, ${removedLabel}, ${result.unchanged} unchanged`);
       } catch (err) {
         const message = (err as Error).message;
         if (message.includes('fetch failed') || message.includes('ECONNREFUSED')) {

--- a/src/lib/embedded-adapter.ts
+++ b/src/lib/embedded-adapter.ts
@@ -198,7 +198,8 @@ export class EmbeddedAdapter implements StoreAdapter {
   async diffGraph(
     graphUri: string,
     localTurtle: string,
-  ): Promise<{ added: string[]; removed: string[]; unchanged: number }> {
+    limit = 50,
+  ): Promise<{ added: string[]; removed: string[]; unchanged: number; addedCount: number; removedCount: number; truncated: boolean }> {
     const localQuads = await parseTurtle(localTurtle);
     const localSet = new Set(
       localQuads.map(
@@ -222,11 +223,19 @@ export class EmbeddedAdapter implements StoreAdapter {
       );
     }
 
-    const added = [...localSet].filter((t) => !remoteSet.has(t));
-    const removed = [...remoteSet].filter((t) => !localSet.has(t));
+    const allAdded = [...localSet].filter((t) => !remoteSet.has(t));
+    const allRemoved = [...remoteSet].filter((t) => !localSet.has(t));
     const unchanged = [...localSet].filter((t) => remoteSet.has(t)).length;
+    const truncated = allAdded.length > limit || allRemoved.length > limit;
 
-    return { added, removed, unchanged };
+    return {
+      added: allAdded.slice(0, limit),
+      removed: allRemoved.slice(0, limit),
+      unchanged,
+      addedCount: allAdded.length,
+      removedCount: allRemoved.length,
+      truncated,
+    };
   }
 
   async getSchemaOverview(graphUri: string): Promise<{

--- a/src/lib/http-adapter.ts
+++ b/src/lib/http-adapter.ts
@@ -166,7 +166,8 @@ export class HttpAdapter implements StoreAdapter {
   async diffGraph(
     graphUri: string,
     localTurtle: string,
-  ): Promise<{ added: string[]; removed: string[]; unchanged: number }> {
+    limit = 50,
+  ): Promise<{ added: string[]; removed: string[]; unchanged: number; addedCount: number; removedCount: number; truncated: boolean }> {
     const localQuads = await parseTurtle(localTurtle);
     const localSet = new Set(
       localQuads.map(
@@ -188,11 +189,19 @@ export class HttpAdapter implements StoreAdapter {
       ),
     );
 
-    const added = [...localSet].filter((t) => !remoteSet.has(t));
-    const removed = [...remoteSet].filter((t) => !localSet.has(t));
+    const allAdded = [...localSet].filter((t) => !remoteSet.has(t));
+    const allRemoved = [...remoteSet].filter((t) => !localSet.has(t));
     const unchanged = [...localSet].filter((t) => remoteSet.has(t)).length;
+    const truncated = allAdded.length > limit || allRemoved.length > limit;
 
-    return { added, removed, unchanged };
+    return {
+      added: allAdded.slice(0, limit),
+      removed: allRemoved.slice(0, limit),
+      unchanged,
+      addedCount: allAdded.length,
+      removedCount: allRemoved.length,
+      truncated,
+    };
   }
 
   async getSchemaOverview(graphUri: string): Promise<{

--- a/src/lib/store-adapter.ts
+++ b/src/lib/store-adapter.ts
@@ -28,7 +28,8 @@ export interface StoreAdapter {
   diffGraph(
     graphUri: string,
     localTurtle: string,
-  ): Promise<{ added: string[]; removed: string[]; unchanged: number }>;
+    limit?: number,
+  ): Promise<{ added: string[]; removed: string[]; unchanged: number; addedCount: number; removedCount: number; truncated: boolean }>;
 
   // Schema introspection
   getSchemaOverview(graphUri: string): Promise<{

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -328,13 +328,15 @@ async function handleDiff(args: Record<string, unknown>): Promise<unknown> {
     throw new Error('content (Turtle) is required');
   }
 
+  const limit = typeof args.limit === 'number' ? args.limit : 50;
+
   const { config, graphUri } = resolveConfig({
     graphUri: args.graphUri as string | undefined,
     graph: args.graph as string | undefined,
   });
 
   const adapter = await createReadyAdapter(config);
-  return await adapter.diffGraph(graphUri, content);
+  return await adapter.diffGraph(graphUri, content, limit);
 }
 
 async function handleGraphList(_args: Record<string, unknown>): Promise<unknown> {
@@ -1225,13 +1227,17 @@ export async function startMcpServer(): Promise<void> {
       },
       {
         name: 'diff',
-        description: 'Compare local Turtle content against the remote graph. Returns added triples (in local but not remote), removed triples (in remote but not local), and count of unchanged triples.',
+        description: 'Compare local Turtle content against the remote graph. Returns added triples (in local but not remote), removed triples (in remote but not local), and count of unchanged triples. Output is limited to avoid blowing up LLM context windows.',
         inputSchema: {
           type: 'object' as const,
           properties: {
             content: {
               type: 'string',
               description: 'Turtle (RDF) content to compare against the remote graph',
+            },
+            limit: {
+              type: 'number',
+              description: 'Maximum number of added/removed triples to return (default: 50). Total counts are always included.',
             },
             graph: {
               type: 'string',

--- a/tests/integration/embedded-adapter.test.ts
+++ b/tests/integration/embedded-adapter.test.ts
@@ -257,6 +257,31 @@ describe('EmbeddedAdapter', () => {
 
       // "unchanged" = present in both
       expect(diff.unchanged).toBe(1);
+
+      // new fields
+      expect(diff.addedCount).toBe(1);
+      expect(diff.removedCount).toBe(1);
+      expect(diff.truncated).toBe(false);
+    });
+
+    it('truncates output when limit is exceeded', async () => {
+      // Insert 5 triples into remote
+      const lines = Array.from({ length: 5 }, (_, i) => `ex:A ex:p ex:R${i} .`);
+      const remote = `@prefix ex: <http://example.org/> .\n${lines.join('\n')}`;
+      await adapter.insertTurtle(GRAPH, remote);
+
+      // Local has 5 different triples — all added, all remote removed
+      const localLines = Array.from({ length: 5 }, (_, i) => `ex:A ex:p ex:L${i} .`);
+      const local = `@prefix ex: <http://example.org/> .\n${localLines.join('\n')}`;
+
+      const diff = await adapter.diffGraph(GRAPH, local, 2);
+
+      expect(diff.added).toHaveLength(2);
+      expect(diff.removed).toHaveLength(2);
+      expect(diff.addedCount).toBe(5);
+      expect(diff.removedCount).toBe(5);
+      expect(diff.unchanged).toBe(0);
+      expect(diff.truncated).toBe(true);
     });
   });
 

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -139,6 +139,9 @@ describe('Workflow: diffGraph scenarios', () => {
     expect(diff.added).toHaveLength(2);
     expect(diff.removed).toHaveLength(0);
     expect(diff.unchanged).toBe(1);
+    expect(diff.addedCount).toBe(2);
+    expect(diff.removedCount).toBe(0);
+    expect(diff.truncated).toBe(false);
   });
 
   it('diff with subset file shows removed triples', async () => {
@@ -162,6 +165,9 @@ describe('Workflow: diffGraph scenarios', () => {
     expect(diff.added).toHaveLength(0);
     expect(diff.removed).toHaveLength(2);
     expect(diff.unchanged).toBe(1);
+    expect(diff.addedCount).toBe(0);
+    expect(diff.removedCount).toBe(2);
+    expect(diff.truncated).toBe(false);
   });
 
   it('diff with identical data shows no changes', async () => {
@@ -180,6 +186,9 @@ describe('Workflow: diffGraph scenarios', () => {
     expect(diff.added).toHaveLength(0);
     expect(diff.removed).toHaveLength(0);
     expect(diff.unchanged).toBe(3);
+    expect(diff.addedCount).toBe(0);
+    expect(diff.removedCount).toBe(0);
+    expect(diff.truncated).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add `limit` parameter (default 50) to `diffGraph` in both adapters
- Return `addedCount`, `removedCount`, and `truncated` flag alongside truncated triple arrays
- Update MCP tool schema with new `limit` parameter
- Update CLI diff command to show truncation info
- Bump version to 0.3.1

Closes #57

## Test plan
- [x] Existing diff tests pass with new fields (addedCount, removedCount, truncated)
- [x] New truncation test: 5 added + 5 removed with limit=2 → arrays truncated, counts correct
- [x] All 144 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)