### PR TITLE
feat: add ask() execution layer — SPARQL template registry + evaluation

### DIFF
--- a/src/lib/ask-engine.ts
+++ b/src/lib/ask-engine.ts
@@ -1,0 +1,192 @@
+import type { StoreAdapter } from './store-adapter.js';
+import { autoScopeQuery } from './sparql-utils.js';
+
+// ── Types ──
+
+export interface AskInput {
+  predicate: string;
+  context: Record<string, string>;
+  record?: boolean;
+  graph?: string;
+  graphUri?: string;
+}
+
+export interface AskOutput {
+  answer: boolean | null;
+  reason?: string;
+  missing?: string[];
+  evaluationUri?: string;
+  bindings?: Array<Record<string, string>>;
+}
+
+interface ResolvedPredicate {
+  uri: string;
+  title: string;
+  sparqlTemplate: string;
+  requiredParams: string[];
+}
+
+// ── Resolve ──
+
+export async function resolvePredicate(
+  adapter: StoreAdapter,
+  predicateName: string,
+  contextGraphUri: string,
+): Promise<ResolvedPredicate | null> {
+  const sparql = `
+    PREFIX otx: <https://opentology.dev/vocab#>
+    SELECT ?uri ?title ?template ?param WHERE {
+      GRAPH <${contextGraphUri}> {
+        ?uri a otx:Predicate ;
+             otx:title ?title ;
+             otx:sparqlTemplate ?template .
+        OPTIONAL { ?uri otx:requiredParam ?param }
+        FILTER(?title = "${predicateName}" || ?uri = <urn:predicate:${predicateName}>)
+      }
+    }
+  `;
+
+  const results = await adapter.sparqlQuery(sparql);
+  const bindings = results.results.bindings;
+  if (bindings.length === 0) return null;
+
+  const first = bindings[0];
+  const requiredParams = bindings
+    .map((b) => b.param?.value)
+    .filter((v): v is string => !!v);
+
+  return {
+    uri: first.uri.value,
+    title: first.title.value,
+    sparqlTemplate: first.template.value,
+    requiredParams: [...new Set(requiredParams)],
+  };
+}
+
+// ── Validate ──
+
+export function validateContext(
+  predicate: ResolvedPredicate,
+  context: Record<string, string>,
+): string[] {
+  return predicate.requiredParams.filter((p) => !(p in context));
+}
+
+// ── Evaluate ──
+
+export function bindTemplate(
+  template: string,
+  context: Record<string, string>,
+  graphUri: string,
+): string {
+  let bound = template;
+  bound = bound.replace(/\{\{graphUri\}\}/g, graphUri);
+  for (const [key, value] of Object.entries(context)) {
+    bound = bound.replace(new RegExp(`\\{\\{${key}\\}\\}`, 'g'), value);
+  }
+  return bound;
+}
+
+export async function evaluate(
+  adapter: StoreAdapter,
+  sparql: string,
+): Promise<{ answer: boolean; bindings?: Array<Record<string, string>> }> {
+  const trimmed = sparql.trim();
+
+  // ASK query → boolean
+  if (/^(PREFIX\s+\S+:\s+<[^>]+>\s+)*ASK\b/i.test(trimmed)) {
+    const answer = await adapter.askQuery(trimmed);
+    return { answer };
+  }
+
+  // SELECT query → has results?
+  const results = await adapter.sparqlQuery(trimmed);
+  const bindings = results.results.bindings.map((b) => {
+    const row: Record<string, string> = {};
+    for (const [k, v] of Object.entries(b)) {
+      row[k] = v.value;
+    }
+    return row;
+  });
+  return { answer: bindings.length > 0, bindings: bindings.length > 0 ? bindings : undefined };
+}
+
+// ── Record ──
+
+export async function recordEvaluation(
+  adapter: StoreAdapter,
+  graphUri: string,
+  predicateUri: string,
+  context: Record<string, string>,
+  answer: boolean | null,
+  sessionUri?: string,
+): Promise<string> {
+  const now = new Date().toISOString().slice(0, 10);
+  const seq = Date.now() % 100000;
+  const evalUri = `urn:evaluation:${now}-${seq}`;
+
+  const inputJson = JSON.stringify(context).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+
+  let turtle = `
+@prefix otx: <https://opentology.dev/vocab#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<${evalUri}> a otx:Evaluation ;
+    otx:predicate <${predicateUri}> ;
+    otx:input "${inputJson}" ;
+    otx:result "${String(answer)}" ;
+    otx:date "${now}"^^xsd:date .
+`;
+
+  if (sessionUri) {
+    turtle += `<${evalUri}> otx:createdIn <${sessionUri}> .\n`;
+  }
+
+  await adapter.insertTurtle(graphUri, turtle);
+  return evalUri;
+}
+
+// ── Main ask() ──
+
+export async function ask(
+  adapter: StoreAdapter,
+  contextGraphUri: string,
+  input: AskInput,
+): Promise<AskOutput> {
+  // 1. Resolve predicate
+  const predicate = await resolvePredicate(adapter, input.predicate, contextGraphUri);
+  if (!predicate) {
+    return { answer: null, reason: `Unknown predicate: "${input.predicate}"` };
+  }
+
+  // 2. Validate required params
+  const missing = validateContext(predicate, input.context);
+  if (missing.length > 0) {
+    return { answer: null, missing, reason: `Missing required parameters: ${missing.join(', ')}` };
+  }
+
+  // 3. Bind template and evaluate
+  const boundSparql = bindTemplate(predicate.sparqlTemplate, input.context, contextGraphUri);
+  const { answer, bindings } = await evaluate(adapter, boundSparql);
+
+  // 4. Optionally record
+  let evaluationUri: string | undefined;
+  if (input.record !== false) {
+    evaluationUri = await recordEvaluation(
+      adapter,
+      contextGraphUri,
+      predicate.uri,
+      input.context,
+      answer,
+    );
+  }
+
+  return {
+    answer,
+    reason: answer
+      ? `Predicate "${predicate.title}" evaluated to true`
+      : `Predicate "${predicate.title}" evaluated to false`,
+    evaluationUri,
+    bindings,
+  };
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -25,6 +25,7 @@ import type { InferenceResult } from '../lib/reasoner.js';
 import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { OTX_BOOTSTRAP_TURTLE } from '../templates/otx-ontology.js';
+import { BUILTIN_PREDICATES_TURTLE } from '../templates/builtin-predicates.js';
 import { generateContextSection, updateClaudeMd, updateGlobalClaudeMd } from '../templates/claude-md-context.js';
 import { generateHookScript } from '../templates/session-start-hook.js';
 import { generatePreEditHookScript } from '../templates/pre-edit-hook.js';
@@ -33,6 +34,7 @@ import { generatePostErrorHookScript } from '../templates/post-error-hook.js';
 import { generateStopSessionHookScript } from '../templates/stop-session-hook.js';
 import { generateSlashCommands } from '../templates/slash-commands.js';
 import { runDoctor } from '../lib/doctor.js';
+import { ask } from '../lib/ask-engine.js';
 
 export interface ContextLoadOutput {
   projectId: string;
@@ -709,7 +711,20 @@ async function handleContextInit(args: Record<string, unknown>): Promise<unknown
     if (!config.files[contextUri].includes(relPath)) {
       config.files[contextUri].push(relPath);
     }
-    actions.push('Bootstrapped otx ontology (13 classes, 24 properties)');
+    actions.push('Bootstrapped otx ontology (15 classes, 29 properties)');
+  }
+
+  // Bootstrap built-in predicates
+  const predicatesPath = join(ontologyDir, 'predicates.ttl');
+  if (!existsSync(predicatesPath) || force) {
+    writeFileSync(predicatesPath, BUILTIN_PREDICATES_TURTLE, 'utf-8');
+    if (!config.files) config.files = {};
+    if (!config.files[contextUri]) config.files[contextUri] = [];
+    const predRelPath = '.opentology/predicates.ttl';
+    if (!config.files[contextUri].includes(predRelPath)) {
+      config.files[contextUri].push(predRelPath);
+    }
+    actions.push('Bootstrapped 6 built-in predicates for ask() engine');
   }
 
   // Generate hook script
@@ -1792,6 +1807,37 @@ export async function startMcpServer(): Promise<void> {
           required: ['action'],
         },
       },
+      {
+        name: 'ask',
+        description: 'Evaluate a registered Predicate against the knowledge graph. Predicates are SPARQL templates stored as otx:Predicate in the context graph. Returns a deterministic boolean answer (or null if predicate is unknown or required params are missing). Optionally records the evaluation as otx:Evaluation.',
+        inputSchema: {
+          type: 'object' as const,
+          properties: {
+            predicate: {
+              type: 'string',
+              description: 'Predicate name (e.g. "Module.hasOpenIssue") or full URI (urn:predicate:Module.hasOpenIssue)',
+            },
+            context: {
+              type: 'object' as const,
+              description: 'Key-value pairs to bind into the SPARQL template (e.g. { "module": "src/lib/reasoner.ts" })',
+              additionalProperties: { type: 'string' },
+            },
+            record: {
+              type: 'boolean',
+              description: 'If false, skip recording the evaluation result to the graph. Default: true',
+            },
+            graph: {
+              type: 'string',
+              description: 'Logical graph name. Resolves to a graph URI via config.',
+            },
+            graphUri: {
+              type: 'string',
+              description: 'Named graph URI (uses context graph if omitted)',
+            },
+          },
+          required: ['predicate', 'context'],
+        },
+      },
     ],
   }));
 
@@ -1886,6 +1932,22 @@ export async function startMcpServer(): Promise<void> {
         case 'doctor':
           result = await runDoctor();
           break;
+        case 'ask': {
+          const askArgs = args as Record<string, unknown>;
+          const askConfig = loadConfig();
+          const askGraphUri = askArgs.graphUri as string
+            || (askArgs.graph ? resolveGraphUri(askConfig, askArgs.graph as string) : `${askConfig.graphUri}/context`);
+          const askAdapter = await createReadyAdapter(askConfig);
+          result = await ask(askAdapter, askGraphUri, {
+            predicate: askArgs.predicate as string,
+            context: (askArgs.context as Record<string, string>) || {},
+            record: askArgs.record as boolean | undefined,
+          });
+          if ((result as { evaluationUri?: string }).evaluationUri) {
+            await persistGraph(askAdapter, askConfig, askGraphUri);
+          }
+          break;
+        }
         default:
           throw new Error(`Unknown tool: ${name}`);
       }

--- a/src/templates/builtin-predicates.ts
+++ b/src/templates/builtin-predicates.ts
@@ -1,0 +1,33 @@
+export const BUILTIN_PREDICATES_TURTLE = `\
+@prefix otx: <https://opentology.dev/vocab#> .
+
+<urn:predicate:Module.hasOpenIssue> a otx:Predicate ;
+    otx:title "Module.hasOpenIssue" ;
+    otx:sparqlTemplate """SELECT ?issue ?title WHERE { GRAPH <{{graphUri}}> { ?issue a otx:Issue ; otx:status "open" ; otx:title ?title ; otx:relatedTo <urn:module:{{module}}> . } }""" ;
+    otx:requiredParam "module" .
+
+<urn:predicate:Module.hasDependents> a otx:Predicate ;
+    otx:title "Module.hasDependents" ;
+    otx:sparqlTemplate """SELECT ?dep ?title WHERE { GRAPH <{{graphUri}}> { ?dep a otx:Module ; otx:dependsOn <urn:module:{{module}}> . OPTIONAL { ?dep otx:title ?title } } }""" ;
+    otx:requiredParam "module" .
+
+<urn:predicate:Decision.exists> a otx:Predicate ;
+    otx:title "Decision.exists" ;
+    otx:sparqlTemplate """ASK { GRAPH <{{graphUri}}> { ?d a otx:Decision ; otx:title ?t . FILTER(CONTAINS(LCASE(?t), LCASE("{{keyword}}"))) } }""" ;
+    otx:requiredParam "keyword" .
+
+<urn:predicate:Knowledge.exists> a otx:Predicate ;
+    otx:title "Knowledge.exists" ;
+    otx:sparqlTemplate """SELECT ?k ?title ?body WHERE { GRAPH <{{graphUri}}> { ?k a otx:Knowledge ; otx:title ?title . OPTIONAL { ?k otx:body ?body } FILTER(CONTAINS(LCASE(?title), LCASE("{{keyword}}"))) } } LIMIT 10""" ;
+    otx:requiredParam "keyword" .
+
+<urn:predicate:Issue.isResolved> a otx:Predicate ;
+    otx:title "Issue.isResolved" ;
+    otx:sparqlTemplate """ASK { GRAPH <{{graphUri}}> { <{{issue}}> a otx:Issue ; otx:status ?s . FILTER(?s = "resolved" || ?s = "closed") } }""" ;
+    otx:requiredParam "issue" .
+
+<urn:predicate:Module.hasSymbols> a otx:Predicate ;
+    otx:title "Module.hasSymbols" ;
+    otx:sparqlTemplate """SELECT ?sym ?type WHERE { GRAPH <{{graphUri}}> { ?sym otx:definedIn <urn:module:{{module}}> . ?sym a ?type . FILTER(?type IN (otx:Class, otx:Interface, otx:Function, otx:Method)) } }""" ;
+    otx:requiredParam "module" .
+`;

--- a/src/templates/otx-ontology.ts
+++ b/src/templates/otx-ontology.ts
@@ -77,5 +77,15 @@ otx:evidence a owl:ObjectProperty ; rdfs:domain otx:Insight .
 
 # Decision chaining
 otx:supersedes a owl:ObjectProperty ; rdfs:domain otx:Decision ; rdfs:range otx:Decision .
+
+# ── Ask execution layer ──
+otx:Predicate a owl:Class .
+otx:Evaluation a owl:Class .
+
+otx:sparqlTemplate a owl:DatatypeProperty ; rdfs:domain otx:Predicate ; rdfs:range xsd:string .
+otx:requiredParam a owl:DatatypeProperty ; rdfs:domain otx:Predicate ; rdfs:range xsd:string .
+otx:predicate a owl:ObjectProperty ; rdfs:domain otx:Evaluation ; rdfs:range otx:Predicate .
+otx:input a owl:DatatypeProperty ; rdfs:domain otx:Evaluation ; rdfs:range xsd:string .
+otx:result a owl:DatatypeProperty ; rdfs:domain otx:Evaluation ; rdfs:range xsd:string .
 `;
 

--- a/src/templates/slash-commands.ts
+++ b/src/templates/slash-commands.ts
@@ -297,5 +297,61 @@ The tool starts a local web server and returns a URL. Tell the user:
 If context is not initialized, suggest running /context-init first.
 `,
     },
+    {
+      filename: 'context-ask.md',
+      content: `Evaluate a registered Predicate against the OpenTology knowledge graph using the \`ask\` MCP tool.
+
+## Step 1 — List available predicates
+
+\`\`\`sparql
+PREFIX otx: <https://opentology.dev/vocab#>
+SELECT ?uri ?title ?param WHERE {
+  GRAPH <https://opentology.dev/opentology-context/context> {
+    ?uri a otx:Predicate ; otx:title ?title .
+    OPTIONAL { ?uri otx:requiredParam ?param }
+  }
+} ORDER BY ?title
+\`\`\`
+
+Show the user the available predicates with their required parameters.
+
+## Step 2 — Ask the user
+
+Ask which predicate to evaluate and what context values to provide.
+
+If the user describes their question in natural language, match it to the closest predicate from the list.
+
+## Step 3 — Call the ask tool
+
+Use the \`ask\` MCP tool with the predicate name and context values.
+
+Example:
+\`\`\`json
+{
+  "predicate": "Module.hasOpenIssue",
+  "context": { "module": "src/lib/reasoner.ts" }
+}
+\`\`\`
+
+## Step 4 — Display results
+
+Show:
+- **Answer**: true / false / null
+- **Reason**: why this answer was given
+- **Bindings** (if SELECT): matching results
+- **Evaluation URI**: where the result was recorded
+
+If no predicates are registered yet, suggest running /context-init to set up built-in predicates or show how to register a custom one:
+
+\`\`\`turtle
+@prefix otx: <https://opentology.dev/vocab#> .
+
+<urn:predicate:MyEntity.myCheck> a otx:Predicate ;
+    otx:title "MyEntity.myCheck" ;
+    otx:sparqlTemplate """ASK { GRAPH <{{graphUri}}> { ... FILTER(... = "{{param}}") } }""" ;
+    otx:requiredParam "param" .
+\`\`\`
+`,
+    },
   ];
 }

--- a/tests/unit/ask-engine.test.ts
+++ b/tests/unit/ask-engine.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  resolvePredicate,
+  validateContext,
+  bindTemplate,
+  evaluate,
+  recordEvaluation,
+  ask,
+} from '../../src/lib/ask-engine.js';
+import type { StoreAdapter, SparqlResults } from '../../src/lib/store-adapter.js';
+
+// ── Mock adapter ──
+
+function createMockAdapter(overrides: Partial<StoreAdapter> = {}): StoreAdapter {
+  return {
+    sparqlQuery: vi.fn().mockResolvedValue({ head: { vars: [] }, results: { bindings: [] } }),
+    askQuery: vi.fn().mockResolvedValue(false),
+    sparqlUpdate: vi.fn().mockResolvedValue(undefined),
+    constructQuery: vi.fn().mockResolvedValue(''),
+    insertTurtle: vi.fn().mockResolvedValue(undefined),
+    dropGraph: vi.fn().mockResolvedValue(undefined),
+    deleteTriples: vi.fn().mockResolvedValue(undefined),
+    getGraphTripleCount: vi.fn().mockResolvedValue(0),
+    exportGraph: vi.fn().mockResolvedValue(''),
+    diffGraph: vi.fn().mockResolvedValue({ added: [], removed: [], unchanged: 0, addedCount: 0, removedCount: 0, truncated: false }),
+    getSchemaOverview: vi.fn().mockResolvedValue({ prefixes: {}, classes: [], properties: [], tripleCount: 0 }),
+    getClassDetails: vi.fn().mockResolvedValue({ classUri: '', instanceCount: 0, properties: [], sampleTriples: [] }),
+    getSchemaRelations: vi.fn().mockResolvedValue({ subClassOf: [], domainRange: [] }),
+    ...overrides,
+  };
+}
+
+const GRAPH_URI = 'https://opentology.dev/test/context';
+
+// ── resolvePredicate ──
+
+describe('resolvePredicate', () => {
+  it('returns null when no predicate found', async () => {
+    const adapter = createMockAdapter();
+    const result = await resolvePredicate(adapter, 'Unknown.pred', GRAPH_URI);
+    expect(result).toBeNull();
+  });
+
+  it('resolves predicate with title and params', async () => {
+    const bindings = [
+      {
+        uri: { type: 'uri', value: 'urn:predicate:Module.hasOpenIssue' },
+        title: { type: 'literal', value: 'Module.hasOpenIssue' },
+        template: { type: 'literal', value: 'ASK { ?s a otx:Issue }' },
+        param: { type: 'literal', value: 'module' },
+      },
+    ];
+    const adapter = createMockAdapter({
+      sparqlQuery: vi.fn().mockResolvedValue({
+        head: { vars: ['uri', 'title', 'template', 'param'] },
+        results: { bindings },
+      }),
+    });
+
+    const result = await resolvePredicate(adapter, 'Module.hasOpenIssue', GRAPH_URI);
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe('Module.hasOpenIssue');
+    expect(result!.requiredParams).toEqual(['module']);
+    expect(result!.sparqlTemplate).toBe('ASK { ?s a otx:Issue }');
+  });
+
+  it('deduplicates required params', async () => {
+    const bindings = [
+      {
+        uri: { type: 'uri', value: 'urn:predicate:Test' },
+        title: { type: 'literal', value: 'Test' },
+        template: { type: 'literal', value: 'ASK { }' },
+        param: { type: 'literal', value: 'x' },
+      },
+      {
+        uri: { type: 'uri', value: 'urn:predicate:Test' },
+        title: { type: 'literal', value: 'Test' },
+        template: { type: 'literal', value: 'ASK { }' },
+        param: { type: 'literal', value: 'x' },
+      },
+    ];
+    const adapter = createMockAdapter({
+      sparqlQuery: vi.fn().mockResolvedValue({
+        head: { vars: ['uri', 'title', 'template', 'param'] },
+        results: { bindings },
+      }),
+    });
+
+    const result = await resolvePredicate(adapter, 'Test', GRAPH_URI);
+    expect(result!.requiredParams).toEqual(['x']);
+  });
+});
+
+// ── validateContext ──
+
+describe('validateContext', () => {
+  const predicate = {
+    uri: 'urn:predicate:Test',
+    title: 'Test',
+    sparqlTemplate: '',
+    requiredParams: ['module', 'status'],
+  };
+
+  it('returns empty array when all params provided', () => {
+    expect(validateContext(predicate, { module: 'a', status: 'open' })).toEqual([]);
+  });
+
+  it('returns missing params', () => {
+    expect(validateContext(predicate, { module: 'a' })).toEqual(['status']);
+  });
+
+  it('returns all params when none provided', () => {
+    expect(validateContext(predicate, {})).toEqual(['module', 'status']);
+  });
+});
+
+// ── bindTemplate ──
+
+describe('bindTemplate', () => {
+  it('replaces graphUri and context params', () => {
+    const template = 'ASK { GRAPH <{{graphUri}}> { ?s otx:relatedTo <urn:module:{{module}}> } }';
+    const result = bindTemplate(template, { module: 'src/lib/foo.ts' }, GRAPH_URI);
+    expect(result).toBe(`ASK { GRAPH <${GRAPH_URI}> { ?s otx:relatedTo <urn:module:src/lib/foo.ts> } }`);
+  });
+
+  it('replaces multiple occurrences', () => {
+    const template = '{{x}} and {{x}}';
+    expect(bindTemplate(template, { x: 'val' }, GRAPH_URI)).toBe('val and val');
+  });
+});
+
+// ── evaluate ──
+
+describe('evaluate', () => {
+  it('delegates ASK queries to askQuery', async () => {
+    const adapter = createMockAdapter({ askQuery: vi.fn().mockResolvedValue(true) });
+    const result = await evaluate(adapter, 'ASK { ?s ?p ?o }');
+    expect(result.answer).toBe(true);
+    expect(adapter.askQuery).toHaveBeenCalledWith('ASK { ?s ?p ?o }');
+  });
+
+  it('handles ASK with PREFIX', async () => {
+    const adapter = createMockAdapter({ askQuery: vi.fn().mockResolvedValue(false) });
+    const sparql = 'PREFIX otx: <https://opentology.dev/vocab#>\nASK { ?s a otx:Issue }';
+    await evaluate(adapter, sparql);
+    expect(adapter.askQuery).toHaveBeenCalled();
+  });
+
+  it('handles SELECT queries — returns true when bindings exist', async () => {
+    const adapter = createMockAdapter({
+      sparqlQuery: vi.fn().mockResolvedValue({
+        head: { vars: ['s'] },
+        results: { bindings: [{ s: { type: 'uri', value: 'urn:test' } }] },
+      }),
+    });
+    const result = await evaluate(adapter, 'SELECT ?s WHERE { ?s ?p ?o }');
+    expect(result.answer).toBe(true);
+    expect(result.bindings).toEqual([{ s: 'urn:test' }]);
+  });
+
+  it('handles SELECT queries — returns false when empty', async () => {
+    const adapter = createMockAdapter();
+    const result = await evaluate(adapter, 'SELECT ?s WHERE { ?s ?p ?o }');
+    expect(result.answer).toBe(false);
+    expect(result.bindings).toBeUndefined();
+  });
+});
+
+// ── recordEvaluation ──
+
+describe('recordEvaluation', () => {
+  it('inserts evaluation turtle with correct structure', async () => {
+    const adapter = createMockAdapter();
+    const uri = await recordEvaluation(
+      adapter,
+      GRAPH_URI,
+      'urn:predicate:Test',
+      { module: 'foo.ts' },
+      true,
+    );
+
+    expect(uri).toMatch(/^urn:evaluation:\d{4}-\d{2}-\d{2}-\d+$/);
+    expect(adapter.insertTurtle).toHaveBeenCalledOnce();
+
+    const turtle = (adapter.insertTurtle as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    expect(turtle).toContain('a otx:Evaluation');
+    expect(turtle).toContain('otx:predicate <urn:predicate:Test>');
+    expect(turtle).toContain('otx:result "true"');
+  });
+
+  it('includes session link when provided', async () => {
+    const adapter = createMockAdapter();
+    await recordEvaluation(
+      adapter,
+      GRAPH_URI,
+      'urn:predicate:Test',
+      {},
+      false,
+      'urn:session:2026-04-06',
+    );
+
+    const turtle = (adapter.insertTurtle as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    expect(turtle).toContain('otx:createdIn <urn:session:2026-04-06>');
+  });
+});
+
+// ── ask (integration) ──
+
+describe('ask', () => {
+  it('returns null answer for unknown predicate', async () => {
+    const adapter = createMockAdapter();
+    const result = await ask(adapter, GRAPH_URI, {
+      predicate: 'NonExistent',
+      context: {},
+    });
+    expect(result.answer).toBeNull();
+    expect(result.reason).toContain('Unknown predicate');
+  });
+
+  it('returns null with missing params', async () => {
+    const adapter = createMockAdapter({
+      sparqlQuery: vi.fn().mockResolvedValue({
+        head: { vars: ['uri', 'title', 'template', 'param'] },
+        results: {
+          bindings: [
+            {
+              uri: { type: 'uri', value: 'urn:predicate:Test' },
+              title: { type: 'literal', value: 'Test' },
+              template: { type: 'literal', value: 'ASK { }' },
+              param: { type: 'literal', value: 'required_field' },
+            },
+          ],
+        },
+      }),
+    });
+
+    const result = await ask(adapter, GRAPH_URI, {
+      predicate: 'Test',
+      context: {},
+    });
+    expect(result.answer).toBeNull();
+    expect(result.missing).toEqual(['required_field']);
+  });
+
+  it('evaluates ASK predicate and records result', async () => {
+    // First call: resolvePredicate (sparqlQuery), second call: not used for ASK
+    let callCount = 0;
+    const adapter = createMockAdapter({
+      sparqlQuery: vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          // resolvePredicate
+          return {
+            head: { vars: ['uri', 'title', 'template', 'param'] },
+            results: {
+              bindings: [
+                {
+                  uri: { type: 'uri', value: 'urn:predicate:Module.hasOpenIssue' },
+                  title: { type: 'literal', value: 'Module.hasOpenIssue' },
+                  template: { type: 'literal', value: 'ASK { GRAPH <{{graphUri}}> { ?i a <https://opentology.dev/vocab#Issue> } }' },
+                  param: { type: 'literal', value: 'module' },
+                },
+              ],
+            },
+          };
+        }
+        return { head: { vars: [] }, results: { bindings: [] } };
+      }),
+      askQuery: vi.fn().mockResolvedValue(true),
+    });
+
+    const result = await ask(adapter, GRAPH_URI, {
+      predicate: 'Module.hasOpenIssue',
+      context: { module: 'src/lib/foo.ts' },
+    });
+
+    expect(result.answer).toBe(true);
+    expect(result.evaluationUri).toMatch(/^urn:evaluation:/);
+    expect(adapter.insertTurtle).toHaveBeenCalledOnce();
+  });
+
+  it('skips recording when record=false', async () => {
+    const adapter = createMockAdapter({
+      sparqlQuery: vi.fn().mockResolvedValue({
+        head: { vars: ['uri', 'title', 'template'] },
+        results: {
+          bindings: [
+            {
+              uri: { type: 'uri', value: 'urn:predicate:Simple' },
+              title: { type: 'literal', value: 'Simple' },
+              template: { type: 'literal', value: 'ASK { ?s ?p ?o }' },
+            },
+          ],
+        },
+      }),
+      askQuery: vi.fn().mockResolvedValue(false),
+    });
+
+    const result = await ask(adapter, GRAPH_URI, {
+      predicate: 'Simple',
+      context: {},
+      record: false,
+    });
+
+    expect(result.answer).toBe(false);
+    expect(result.evaluationUri).toBeUndefined();
+    expect(adapter.insertTurtle).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Ontology에 정의된 Predicate(SPARQL 템플릿)를 평가하고 결과를 그래프에 기록하는 실행 레이어 추가
- 새 온톨로지 클래스: `otx:Predicate`, `otx:Evaluation`
- MCP `ask` tool + `/context-ask` slash command
- 6개 built-in predicates (Module.hasOpenIssue, Module.hasDependents, Decision.exists, Knowledge.exists, Issue.isResolved, Module.hasSymbols)

## Test plan

- [x] 18 unit tests 통과 (resolve, validate, bind, evaluate, record)
- [x] 전체 163/163 테스트 통과
- [x] TypeScript 빌드 성공

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)