### PR TITLE
fix: stabilize versioning, hooks checks, and deep scan git noise

### DIFF
--- a/.sisyphus/plans/stability-risk-fixes.md
+++ b/.sisyphus/plans/stability-risk-fixes.md
@@ -1,0 +1,124 @@
+# Plan — Stability / Risk Fixes
+
+## Goal
+Stabilize OpenTology’s core workflows by fixing the highest-impact “Risks” identified in the audit:
+- Version reporting drift (CLI vs package vs MCP)
+- Hook + Claude settings install/repair reliability (doctor warning)
+- Git boundary noise ("fatal: not a git repository" leaking to users/tests)
+- Stubbed language detection causing unnecessary work (deep-scan)
+- Silent failures / low observability at key seams
+
+## Non-goals
+- Implement roadmap features (OWL reasoning, remote ontology import, ontology snapshot versioning)
+- Add new MCP tools or change tool schemas
+- Create commits / push / PR (unless user explicitly requests later)
+
+## Changes (by priority)
+
+### P0 — Version coherence
+1) Unify version source of truth:
+   - CLI `opentology --version` must reflect `package.json` version.
+   - MCP server `{ name, version }` must match `package.json` version.
+2) Add a unit test that asserts reported versions equal `package.json`.
+
+Files likely touched:
+- `src/index.ts`
+- `src/mcp/server.ts`
+- `tests/unit/*` (new test)
+
+### P0 — Git boundary: no stderr fatals
+3) Deep scan file discovery must not leak git errors:
+   - Before `git -C <root> ls-files ...`, detect git-work-tree reliably.
+   - Use a helper that executes git with stderr captured and returns a boolean.
+   - Ensure fallback path is taken cleanly (no user-facing fatals).
+
+Files likely touched:
+- `src/lib/deep-scanner.ts`
+- (possibly) `src/lib/context-sync.ts` if it leaks git errors (it currently swallows, but verify behavior)
+
+### P0 — Hook + settings reliability
+4) Make `context init` / `doctor` alignment deterministic:
+   - Identify what `doctor` checks for “SessionStart / PreToolUse” hooks.
+   - Ensure `context_init` installs/repairs the required `.claude/settings.json` entries idempotently.
+   - Ensure `doctor` distinguishes “hooks files exist” vs “Claude settings wired”.
+
+Files likely touched:
+- `src/lib/doctor.ts`
+- `src/mcp/handlers/context.ts` (context_init)
+- `src/templates/*-hook.ts` (only if wiring behavior is wrong)
+
+### P1 — Deep scan: implement `detectLanguages()` (remove stub)
+5) Implement lightweight language detection:
+   - Scan for presence of supported extensions (ts/tsx/js/jsx/py/go/rs/java/swift) with an early-exit walk.
+   - Filter extractors to only those with matching file presence.
+   - Keep the explicit `options.languages` override behavior.
+
+Files likely touched:
+- `src/lib/deep-scanner.ts`
+
+### P1 — Silent catch → explicit warnings (minimal observability)
+6) Replace silent failure in key user-facing results with warnings:
+   - `context_load` meta triple counts: if counts fail, return a warning string.
+   - `graph-server` schema refresh failures: surface a warning (log or explicit status) instead of swallowing.
+
+Files likely touched:
+- `src/mcp/handlers/context.ts`
+- `src/lib/graph-server.ts`
+
+## Verification
+
+### Global
+- Run `npm run build`
+- Run `npm test`
+
+### Task 1–2: Version coherence
+**Steps**
+1) `node dist/index.js --version` prints exactly `package.json` `version`
+2) Unit test asserts `getPackageVersion()` equals `package.json` `version`
+3) Unit test asserts MCP server version field equals `package.json` `version`
+
+**Expected**
+- No hardcoded version strings remain for CLI/MCP
+- CLI and MCP report the same version
+
+### Task 3: Git boundary (no stderr fatals)
+**Steps**
+1) In vitest, run `deepScan(tempDirWithoutGit)` while intercepting `process.stderr.write`
+2) Assert stderr does **not** contain `fatal: not a git repository`
+
+**Expected**
+- Deep scan gracefully falls back when not in a git work tree
+- No user-visible git fatal output
+
+### Task 4: Hook + settings reliability
+**Steps**
+1) Create a temp project dir with `.opentology/hooks/*.mjs` present but without `.claude/settings.json`
+2) Run `context_init` and verify `.claude/settings.json` contains:
+   - `hooks.SessionStart` command `node .opentology/hooks/session-start.mjs`
+   - `hooks.PreToolUse` matcher `Edit|Write` command `node .opentology/hooks/pre-edit.mjs`
+3) Run `runDoctor()` and verify `Settings` check is `ok`
+
+**Expected**
+- `context_init` is idempotent and self-healing
+- `doctor` output matches the on-disk reality
+
+### Task 5: detectLanguages filtering
+**Steps**
+1) Create a temp project dir with only `.py` files present
+2) Run `deepScan(tempDir)` and verify only Python extractor is attempted (via warnings/metrics or by ensuring TS extractor does not produce availability warnings)
+
+**Expected**
+- Deep scan does not waste time on irrelevant extractors
+
+### Task 6: Warnings/observability
+**Steps**
+1) Force `getGraphTripleCount` to throw (mock adapter or use an invalid graph URI) and verify `context_load` includes a warning instead of silently returning `0`
+2) In graph UI, force `/api/schema` to fail and confirm a visible warning is emitted (console warning at minimum)
+
+**Expected**
+- Failures are visible and actionable, not silent
+
+## Rollback/Safety
+- Keep changes small and localized.
+- Avoid changing public MCP tool schemas.
+- No commits will be created during this execution (unless explicitly requested).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opentology",
-  "version": "0.3.9",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opentology",
-      "version": "0.3.9",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,24 @@
+import { Command } from 'commander';
+import { registerInit } from './commands/init.js';
+import { registerQuery } from './commands/query.js';
+import { registerMcp } from './commands/mcp.js';
+import { getPackageVersion } from './lib/version.js';
+
+export function createProgram(): Command {
+  const program = new Command();
+  program
+    .name('opentology')
+    .version(getPackageVersion())
+    .description('CLI-managed RDF/SPARQL infrastructure — Supabase for RDF');
+
+  registerInit(program);
+  registerQuery(program);
+  registerMcp(program);
+
+  return program;
+}
+
+export async function main(argv: string[]): Promise<void> {
+  const program = createProgram();
+  program.parse(argv);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,4 @@
 #!/usr/bin/env node
-import { Command } from 'commander';
-import { registerInit } from './commands/init.js';
-import { registerQuery } from './commands/query.js';
-import { registerMcp } from './commands/mcp.js';
+import { main } from './cli.js';
 
-const program = new Command();
-program
-  .name('opentology')
-  .version('0.2.4')
-  .description('CLI-managed RDF/SPARQL infrastructure — Supabase for RDF');
-
-registerInit(program);
-registerQuery(program);
-registerMcp(program);
-
-program.parse(process.argv);
+await main(process.argv);

--- a/src/lib/deep-scanner.ts
+++ b/src/lib/deep-scanner.ts
@@ -4,6 +4,7 @@
  */
 
 import type { LanguageExtractor, DependencyModel } from './language-extractor.js';
+import { execFileSync } from 'node:child_process';
 import { TypeScriptExtractor } from './deep-scanner-ts.js';
 import { PythonExtractor } from './extractors/python.js';
 import { GoExtractor } from './extractors/go.js';
@@ -107,13 +108,66 @@ function getAllExtractors(): LanguageExtractor[] {
   ];
 }
 
-function detectLanguages(rootDir: string, extractors: LanguageExtractor[]): LanguageExtractor[] {
-  // For now, return all available extractors.
-  // Future: scan rootDir for file extensions and filter.
-  return extractors;
+async function detectLanguages(rootDir: string, extractors: LanguageExtractor[]): Promise<LanguageExtractor[]> {
+  const { readdir } = await import('node:fs/promises');
+  const { join, extname } = await import('node:path');
+
+  const excluded = new Set(['.git', 'node_modules', 'dist', 'build', '.opentology', '.claude', '.omc']);
+  const targetExts = new Set(extractors.flatMap((e) => e.extensions.map((x) => x.toLowerCase())));
+  const foundExts = new Set<string>();
+
+  const dirs: string[] = [rootDir];
+  let visited = 0;
+  const maxEntries = 5000;
+
+  while (dirs.length > 0 && foundExts.size < targetExts.size && visited < maxEntries) {
+    const dir = dirs.pop()!;
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      visited++;
+      if (visited >= maxEntries) break;
+
+      if (entry.isDirectory()) {
+        if (excluded.has(entry.name)) continue;
+        dirs.push(join(dir, entry.name));
+        continue;
+      }
+
+      if (!entry.isFile()) continue;
+      const ext = extname(entry.name).toLowerCase();
+      if (targetExts.has(ext)) {
+        foundExts.add(ext);
+        if (foundExts.size >= targetExts.size) break;
+      }
+    }
+  }
+
+  const filtered = extractors.filter((e) => e.extensions.some((x) => foundExts.has(x.toLowerCase())));
+  return filtered.length > 0 ? filtered : extractors;
 }
 
 // ── File discovery ─────────────────────────────────────────────
+
+function isGitWorkTree(rootDir: string): boolean {
+  // Use execFileSync to avoid shell-quoting edge cases.
+  try {
+    const out = execFileSync('git', ['-C', rootDir, 'rev-parse', '--is-inside-work-tree'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 3000,
+      maxBuffer: 1024 * 1024,
+    }).trim();
+    return out === 'true';
+  } catch {
+    return false;
+  }
+}
 
 async function discoverFiles(
   rootDir: string,
@@ -125,17 +179,17 @@ async function discoverFiles(
   // Use git ls-files if inside a git repo, otherwise fall back to find
   const extGlob = extensions.map(e => `*${e}`);
   let stdout: string;
-  try {
+
+  if (isGitWorkTree(rootDir)) {
     stdout = execSync(
       `git -C "${rootDir}" ls-files -- ${extGlob.map(g => `'${g}'`).join(' ')}`,
-      { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 },
+      { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024, stdio: ['ignore', 'pipe', 'ignore'] },
     );
-  } catch {
-    // Not a git repo — fall back
+  } else {
     const patterns = extensions.map(e => `-name '*${e}'`).join(' -o ');
     stdout = execSync(
       `find "${rootDir}" -type f \\( ${patterns} \\) -not -path '*/node_modules/*' -not -path '*/dist/*'`,
-      { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 },
+      { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024, stdio: ['ignore', 'pipe', 'ignore'] },
     );
   }
 
@@ -183,6 +237,7 @@ async function discoverUnsupportedFiles(
     stdout = execSync(`git -C "${rootDir}" ls-files`, {
       encoding: 'utf-8',
       maxBuffer: 10 * 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'ignore'],
     });
   } catch {
     return [];
@@ -266,8 +321,13 @@ export async function deepScan(
     };
   }
 
-  // Collect all extensions from available extractors
-  const allExtensions = available.flatMap(e => e.extensions);
+  // Filter to languages present in the codebase (unless user explicitly requested languages)
+  const activeExtractors = requestedLanguages
+    ? available
+    : await detectLanguages(rootDir, available);
+
+  // Collect all extensions from active extractors
+  const allExtensions = activeExtractors.flatMap(e => e.extensions);
 
   // Discover files
   const { files, total } = await discoverFiles(rootDir, allExtensions, maxFiles);
@@ -280,7 +340,7 @@ export async function deepScan(
       functions: [],
       methodCalls: [],
       unsupportedFiles: [],
-      languageHints: buildLanguageHints(available),
+      languageHints: buildLanguageHints(activeExtractors),
       fileCount: total,
       symbolCount: 0,
       scanDurationMs: Date.now() - start,
@@ -291,11 +351,11 @@ export async function deepScan(
 
   // Group files by extractor
   const filesByExtractor = new Map<LanguageExtractor, string[]>();
-  for (const ext of available) {
+  for (const ext of activeExtractors) {
     filesByExtractor.set(ext, []);
   }
   for (const file of files) {
-    for (const ext of available) {
+    for (const ext of activeExtractors) {
       if (ext.extensions.some(e => file.endsWith(e))) {
         filesByExtractor.get(ext)!.push(file);
         break;
@@ -351,7 +411,7 @@ export async function deepScan(
     + functions.length;
 
   // Discover unsupported language files
-  const supportedExtensions = new Set(available.flatMap(e => e.extensions));
+  const supportedExtensions = new Set(activeExtractors.flatMap(e => e.extensions));
   const unsupportedFiles = await discoverUnsupportedFiles(rootDir, supportedExtensions);
 
   return {
@@ -361,7 +421,7 @@ export async function deepScan(
     functions,
     methodCalls,
     unsupportedFiles,
-    languageHints: buildLanguageHints(available),
+    languageHints: buildLanguageHints(activeExtractors),
     fileCount: files.length,
     symbolCount,
     scanDurationMs: Date.now() - start,

--- a/src/lib/doctor.ts
+++ b/src/lib/doctor.ts
@@ -49,20 +49,32 @@ export async function runDoctor(): Promise<CheckResult[]> {
     results.push({ name: 'Hooks', status: 'warn', message: 'Hook scripts missing. Run `opentology context init`.' });
   }
 
-  // 5. Hook registration in .claude/settings.json
-  const settingsPath = join(process.cwd(), '.claude', 'settings.json');
-  if (existsSync(settingsPath)) {
+  // 5. Hook registration in Claude settings
+  const settingsJsonPath = join(process.cwd(), '.claude', 'settings.json');
+  const settingsLocalPath = join(process.cwd(), '.claude', 'settings.local.json');
+  const settingsPath = existsSync(settingsJsonPath)
+    ? settingsJsonPath
+    : (existsSync(settingsLocalPath) ? settingsLocalPath : null);
+
+  if (settingsPath) {
     try {
-      const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
-      const hooks = settings.hooks ?? {};
-      const hasSession = (hooks.SessionStart ?? []).some(
-        (h: Record<string, string>) => h.command?.includes('session-start.mjs')
-      );
-      const hasPreEdit = (hooks.PreToolUse ?? []).some(
-        (h: Record<string, string>) => h.command?.includes('pre-edit.mjs')
-      );
+      type HookCommand = { command?: string };
+      type HookRule = { hooks?: HookCommand[] };
+      type HookConfig = { SessionStart?: HookRule[]; PreToolUse?: HookRule[] };
+
+      const settings = JSON.parse(readFileSync(settingsPath, 'utf-8')) as { hooks?: HookConfig };
+      const hooks: HookConfig = settings.hooks ?? {};
+
+      const hasHook = (key: keyof HookConfig, needle: string): boolean => {
+        const rules = hooks[key] ?? [];
+        return rules.some((rule) => (rule.hooks ?? []).some((h) => typeof h.command === 'string' && h.command.includes(needle)));
+      };
+
+      const hasSession = hasHook('SessionStart', 'session-start.mjs');
+      const hasPreEdit = hasHook('PreToolUse', 'pre-edit.mjs');
+
       if (hasSession && hasPreEdit) {
-        results.push({ name: 'Settings', status: 'ok', message: 'Both hooks registered in .claude/settings.json' });
+        results.push({ name: 'Settings', status: 'ok', message: `Both hooks registered in ${settingsPath.replace(process.cwd() + '/', '')}` });
       } else {
         const missing = [];
         if (!hasSession) missing.push('SessionStart');
@@ -70,10 +82,10 @@ export async function runDoctor(): Promise<CheckResult[]> {
         results.push({ name: 'Settings', status: 'warn', message: `Missing hooks: ${missing.join(', ')}. Run \`opentology context init\`.` });
       }
     } catch {
-      results.push({ name: 'Settings', status: 'warn', message: 'Cannot parse .claude/settings.json' });
+      results.push({ name: 'Settings', status: 'warn', message: `Cannot parse ${settingsPath.replace(process.cwd() + '/', '')}` });
     }
   } else {
-    results.push({ name: 'Settings', status: 'warn', message: 'No .claude/settings.json found. Run `opentology context init`.' });
+    results.push({ name: 'Settings', status: 'warn', message: 'No Claude settings found (.claude/settings.json or .claude/settings.local.json). Run `opentology context init`.' });
   }
 
   // 6. CLAUDE.md

--- a/src/lib/graph-server.ts
+++ b/src/lib/graph-server.ts
@@ -173,7 +173,9 @@ function html(config: OpenTologyConfig): string {
       try {
         const schema = await fetch('/api/schema').then(r => r.json());
         (schema.classes || []).forEach(c => classSet.add(c));
-      } catch {}
+      } catch (err) {
+        console.warn('Failed to load schema for class highlighting:', err);
+      }
 
       nodesDS = new vis.DataSet();
       edgesDS = new vis.DataSet();
@@ -209,7 +211,9 @@ function html(config: OpenTologyConfig): string {
           const schema = await fetch('/api/schema').then(r => r.json());
           classSet = new Set();
           (schema.classes || []).forEach(c => classSet.add(c));
-        } catch {}
+        } catch (err) {
+          console.warn('Failed to refresh schema for class highlighting:', err);
+        }
         await runQuery();
       } finally {
         btn.innerHTML = '&#8635; Refresh';

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function getPackageVersion(): string {
+  try {
+    const packageJsonUrl = new URL('../../package.json', import.meta.url);
+    const raw = readFileSync(packageJsonUrl, 'utf-8');
+    const parsed: unknown = JSON.parse(raw);
+
+    if (isRecord(parsed) && typeof parsed.version === 'string' && parsed.version.length > 0) {
+      return parsed.version;
+    }
+  } catch {
+    // Best-effort: fall back below.
+  }
+
+  return '0.0.0';
+}

--- a/src/mcp/handlers/context.ts
+++ b/src/mcp/handlers/context.ts
@@ -619,8 +619,17 @@ export async function handleContextLoad(): Promise<ContextLoadOutput> {
     output.warnings!.push(`Decisions query failed: ${(err as Error).message}`);
   }
 
-  try { output.meta.contextTripleCount = await adapter.getGraphTripleCount(contextUri); } catch { /* */ }
-  try { output.meta.sessionsTripleCount = await adapter.getGraphTripleCount(sessionsUri); } catch { /* */ }
+  try {
+    output.meta.contextTripleCount = await adapter.getGraphTripleCount(contextUri);
+  } catch (err) {
+    output.warnings!.push(`contextTripleCount failed: ${(err as Error).message}`);
+  }
+
+  try {
+    output.meta.sessionsTripleCount = await adapter.getGraphTripleCount(sessionsUri);
+  } catch (err) {
+    output.warnings!.push(`sessionsTripleCount failed: ${(err as Error).message}`);
+  }
 
   if (output.warnings!.length === 0) delete output.warnings;
   return output;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -17,6 +17,7 @@ import { startGraphServer } from '../lib/graph-server.js';
 import { generateSlashCommands } from '../templates/slash-commands.js';
 import { runDoctor } from '../lib/doctor.js';
 import { ask } from '../lib/ask-engine.js';
+import { getPackageVersion } from '../lib/version.js';
 
 import { resolveConfig, handleInit, handleValidate, handlePush, handleQuery, handlePull, handleDrop, handleDelete, handleDiff } from './handlers/rdf.js';
 import { handleStatus, handleGraphList, handleGraphCreate, handleGraphDrop, handleRollback, handleDoctor, handleAsk } from './handlers/system.js';
@@ -32,9 +33,13 @@ import {
 
 export type { ContextLoadOutput } from './handlers/context.js';
 
+export function getMcpServerIdentity(): { name: string; version: string } {
+  return { name: 'opentology', version: getPackageVersion() };
+}
+
 export async function startMcpServer(): Promise<void> {
   const server = new Server(
-    { name: 'opentology', version: '0.1.0' },
+    getMcpServerIdentity(),
     { capabilities: { tools: {}, resources: {}, prompts: {} } }
   );
 

--- a/tests/unit/deep-scan-git-noise.test.ts
+++ b/tests/unit/deep-scan-git-noise.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { deepScan } from '../../src/lib/deep-scanner.js';
+
+function makeTempDir(prefix: string): string {
+  const dir = join(tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe('deepScan git boundary', () => {
+  it('does not emit git fatal noise when scanning a non-git directory', async () => {
+    const root = makeTempDir('opentology-nogit');
+    // Make it look like a project with at least one supported file.
+    writeFileSync(join(root, 'a.ts'), 'export const x = 1;\n', 'utf-8');
+
+    const writes: string[] = [];
+
+    type StderrWrite = (chunk: string | Uint8Array, encoding?: BufferEncoding | ((err?: Error) => void), cb?: (err?: Error) => void) => boolean;
+    const stderrRef = process.stderr as unknown as { write: StderrWrite };
+    const orig: StderrWrite = stderrRef.write.bind(process.stderr);
+
+    // Intercept stderr writes in-process.
+    const hook: StderrWrite = (chunk) => {
+      writes.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8'));
+      // Do not forward to real stderr; keep test output clean.
+      return true;
+    };
+
+    stderrRef.write = hook;
+
+    try {
+      const result = await deepScan(root, { maxFiles: 50, timeoutMs: 5000 });
+      expect(result.deepScanAvailable).toBe(true);
+    } finally {
+      stderrRef.write = orig;
+    }
+
+    expect(writes.join('')).not.toMatch(/fatal: not a git repository/i);
+  });
+});

--- a/tests/unit/version.test.ts
+++ b/tests/unit/version.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { getPackageVersion } from '../../src/lib/version.js';
+import { createProgram } from '../../src/cli.js';
+import { getMcpServerIdentity } from '../../src/mcp/server.js';
+
+function readPackageJsonVersion(): string {
+  const raw = readFileSync(new URL('../../package.json', import.meta.url), 'utf-8');
+  const parsed = JSON.parse(raw) as { version?: string };
+  return parsed.version ?? '';
+}
+
+describe('version coherence', () => {
+  it('getPackageVersion matches package.json', () => {
+    expect(getPackageVersion()).toBe(readPackageJsonVersion());
+  });
+
+  it('CLI program version matches package.json', () => {
+    const program = createProgram();
+    const internal = program as unknown as { _version?: string };
+    expect(internal._version).toBe(readPackageJsonVersion());
+  });
+
+  it('MCP server version matches package.json', () => {
+    expect(getMcpServerIdentity().version).toBe(readPackageJsonVersion());
+  });
+});


### PR DESCRIPTION
## Summary
- Unify version reporting across CLI and MCP using package.json as the single source of truth.
- Silence git stderr fatals and filter deep-scan extractors by detected file extensions.
- Improve doctor hook settings detection and surface warnings in context_load + graph UI schema refresh.

## Verification
- npm run build
- npm test

## Notes
- Adds regression tests for version coherence and non-git deepScan stderr noise.